### PR TITLE
feat: 소음일기 캘린더 백엔드 연동

### DIFF
--- a/app/src/main/java/com/kau/ttokttok/_core/network/di/NetworkModule.kt
+++ b/app/src/main/java/com/kau/ttokttok/_core/network/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.kau.ttokttok._core.network.di
 
 import android.content.Context
 import com.kau.ttokttok.data.remote.api.AuthApiService
+import com.kau.ttokttok.data.remote.api.NoiseApiService
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
@@ -22,7 +23,7 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
 
-    private const val BASE_URL = "http://10.0.2.2:8080/"
+    private const val BASE_URL = "http://43.202.51.96/"
 
     // ───────────────────────────────
     // 1️⃣ 기본 로깅 인터셉터
@@ -140,4 +141,13 @@ object NetworkModule {
     fun provideAuthApiService(
         @Named("noAuthRetrofit") retrofit: Retrofit
     ): AuthApiService = retrofit.create(AuthApiService::class.java)
+
+    // ───────────────────────────────
+    // 8️⃣ API 서비스 제공 (auth용 - 소음 일기)
+    // ───────────────────────────────
+    @Provides
+    @Singleton
+    fun provideNoiseApiService(
+        @Named("authRetrofit") retrofit: Retrofit
+    ): NoiseApiService = retrofit.create(NoiseApiService::class.java)
 }

--- a/app/src/main/java/com/kau/ttokttok/data/local/repository/NoiseLogRepositoryImpl.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/local/repository/NoiseLogRepositoryImpl.kt
@@ -1,50 +1,36 @@
 package com.kau.ttokttok.data.local.repository
 
+import com.kau.ttokttok._core.network.auth.TokenProvider
+import com.kau.ttokttok.data.remote.api.NoiseApiService
 import com.kau.ttokttok.domain.model.NoiseLog
 import com.kau.ttokttok.domain.repository.NoiseLogRepository
 import java.util.Calendar
 import java.util.Date
 import javax.inject.Inject
 
-/**
- * 소음 일기 Repository 구현
- * TODO: [백엔드 연동] 현재는 로컬 메모리에만 저장되며, 앱 재시작 시 데이터가 사라집니다.
- * TODO: [백엔드 연동] 실제 API 연동 시 아래 작업이 필요합니다:
- * 1. Retrofit 인터페이스 정의 (NoiseLogApiService)
- * 2. API 엔드포인트 설정
- *    - POST /api/noise-logs (소음일기 저장)
- *    - PUT /api/noise-logs/{id} (소음일기 수정)
- *    - DELETE /api/noise-logs/{id} (소음일기 삭제)
- *    - GET /api/noise-logs (전체 소음일기 조회)
- *    - GET /api/noise-logs/date/{date} (날짜별 소음일기 조회)
- * 3. 인증 토큰 헤더 추가
- * 4. 에러 핸들링 (네트워크 오류, 인증 실패 등)
- * 5. 오프라인 대응 (Room DB와 동기화)
- */
-class NoiseLogRepositoryImpl @Inject constructor() : NoiseLogRepository {
+// 소음 일기 Repository 구현
+// - 로컬 임시 저장: saveNoiseLog, updateNoiseLog, deleteNoiseLog, getAllNoiseLogs, getNoiseLogsByDate
+// - 백엔드 API 연동: getCalendarData, getNoiseRecordsByDate, getTotalCount, getMonthlyCount, getAverageDb, updateNoiseRecordApi
+class NoiseLogRepositoryImpl @Inject constructor(
+    private val noiseApiService: NoiseApiService,
+    private val tokenProvider: TokenProvider
+) : NoiseLogRepository {
 
-    // TODO: [백엔드 연동] Retrofit API Service 인스턴스로 교체
-    // private val apiService: NoiseLogApiService
-
-    // 임시 데이터 (나중에 실제 API로 교체)
+    // 임시 데이터 (로컬 메모리 저장 - 앱 재시작 시 사라짐)
     private val tempLogs = mutableListOf<NoiseLog>()
 
-    // TODO: [백엔드 연동] API 호출로 변경
-    // 예시: apiService.createNoiseLog(noiseLog.toDto())
+    // 로컬 임시 저장
     override suspend fun saveNoiseLog(noiseLog: NoiseLog): Result<NoiseLog> {
         return try {
-            // TODO: [백엔드 연동] 서버에서 생성된 ID를 받아와야 함
             val newLog = noiseLog.copy(id = System.currentTimeMillis().toString())
             tempLogs.add(newLog)
             Result.success(newLog)
         } catch (e: Exception) {
-            // TODO: [백엔드 연동] 네트워크 에러 처리 추가
             Result.failure(e)
         }
     }
 
-    // TODO: [백엔드 연동] API 호출로 변경
-    // 예시: apiService.updateNoiseLog(noiseLog.id, noiseLog.toDto())
+    // 로컬 임시 수정
     override suspend fun updateNoiseLog(noiseLog: NoiseLog): Result<NoiseLog> {
         return try {
             val index = tempLogs.indexOfFirst { it.id == noiseLog.id }
@@ -55,37 +41,30 @@ class NoiseLogRepositoryImpl @Inject constructor() : NoiseLogRepository {
                 Result.failure(Exception("일기를 찾을 수 없습니다"))
             }
         } catch (e: Exception) {
-            // TODO: [백엔드 연동] 네트워크 에러 처리 추가
             Result.failure(e)
         }
     }
 
-    // TODO: [백엔드 연동] API 호출로 변경
-    // 예시: apiService.deleteNoiseLog(id)
+    // 로컬 임시 삭제
     override suspend fun deleteNoiseLog(id: String): Result<Unit> {
         return try {
             tempLogs.removeIf { it.id == id }
             Result.success(Unit)
         } catch (e: Exception) {
-            // TODO: [백엔드 연동] 네트워크 에러 처리 추가
             Result.failure(e)
         }
     }
 
-    // TODO: [백엔드 연동] API 호출로 변경
-    // 예시: apiService.getAllNoiseLogs().map { it.toDomain() }
-    // TODO: [백엔드 연동] 페이징 처리 고려 (데이터가 많을 경우)
+    // 로컬 임시 조회
     override suspend fun getAllNoiseLogs(): Result<List<NoiseLog>> {
         return try {
             Result.success(tempLogs.toList())
         } catch (e: Exception) {
-            // TODO: [백엔드 연동] 네트워크 에러 처리 추가
             Result.failure(e)
         }
     }
 
-    // TODO: [백엔드 연동] API 호출로 변경
-    // 예시: apiService.getNoiseLogsByDate(date.toIsoString())
+    // 로컬 임시 조회 (날짜별 필터링)
     override suspend fun getNoiseLogsByDate(date: Date): Result<List<NoiseLog>> {
         return try {
             val calendar = Calendar.getInstance().apply {
@@ -99,7 +78,6 @@ class NoiseLogRepositoryImpl @Inject constructor() : NoiseLogRepository {
             val targetMonth = calendar.get(Calendar.MONTH)
             val targetDay = calendar.get(Calendar.DAY_OF_MONTH)
 
-            // TODO: [백엔드 연동] 서버에서 날짜 필터링된 데이터를 받아오도록 변경
             val filtered = tempLogs.filter { log ->
                 val logCalendar = Calendar.getInstance().apply {
                     time = log.measuredAt
@@ -114,8 +92,245 @@ class NoiseLogRepositoryImpl @Inject constructor() : NoiseLogRepository {
             }
             Result.success(filtered)
         } catch (e: Exception) {
-            // TODO: [백엔드 연동] 네트워크 에러 처리 추가
             Result.failure(e)
+        }
+    }
+
+    // [백엔드 API 연동] 캘린더 월별 데이터 조회
+    override suspend fun getCalendarData(
+        userId: Long,
+        year: Int,
+        month: Int
+    ): Result<Map<String, Boolean>> {
+        return try {
+            val token = tokenProvider.getTokenOrNull() ?: return Result.failure(Exception("인증 토큰이 없습니다"))
+
+            val response = noiseApiService.getCalendarData(
+                userId = userId,
+                year = year,
+                month = month,
+                authorization = "Bearer $token"
+            )
+
+            if (response.isSuccessful && response.body() != null) {
+                val calendarResponse = response.body()!!
+
+                if (calendarResponse.isSuccess) {
+                    // API 응답을 Map으로 변환 (날짜 -> hasNoiseLog)
+                    val calendarMap = calendarResponse.result.data.associate { dayData ->
+                        dayData.date to dayData.hasNoiseLog
+                    }
+                    Result.success(calendarMap)
+                } else {
+                    Result.failure(Exception(calendarResponse.message))
+                }
+            } else {
+                Result.failure(Exception("서버 응답 오류: ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    // [백엔드 API 연동] 날짜별 소음 기록 상세 조회
+    override suspend fun getNoiseRecordsByDate(date: String): Result<List<NoiseLog>> {
+        return try {
+            val token = tokenProvider.getTokenOrNull() ?: return Result.failure(Exception("인증 토큰이 없습니다"))
+
+            val response = noiseApiService.getNoiseRecordsByDate(
+                date = date,
+                authorization = "Bearer $token"
+            )
+
+            if (response.isSuccessful && response.body() != null) {
+                val recordsResponse = response.body()!!
+
+                if (recordsResponse.isSuccess) {
+                    // API 응답을 NoiseLog 도메인 모델로 변환
+                    val noiseLogs = recordsResponse.result.records.map { record ->
+                        NoiseLog(
+                            id = record.recordId.toString(),
+                            noiseType = record.noiseType,
+                            maxDecibel = record.noiseLevel.toDouble(),
+                            avgDecibel = record.noiseLevel.toDouble(),
+                            memo = record.memo ?: "",
+                            measuredAt = parseDateTime(record.logDate, record.logTime),
+                            hasReport = false // 기본값
+                        )
+                    }
+                    Result.success(noiseLogs)
+                } else {
+                    Result.failure(Exception(recordsResponse.message))
+                }
+            } else {
+                Result.failure(Exception("서버 응답 오류: ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    // 날짜와 시간 문자열을 Date 객체로 변환
+    private fun parseDateTime(dateStr: String, timeStr: String): Date {
+        return try {
+            val dateTimeStr = "$dateStr $timeStr"
+            val format = java.text.SimpleDateFormat("yyyy-MM-dd HH:mm", java.util.Locale.getDefault())
+            format.parse(dateTimeStr) ?: Date()
+        } catch (e: Exception) {
+            Date()
+        }
+    }
+
+    // [백엔드 API 연동] 총 소음 기록 수 조회
+    override suspend fun getTotalCount(userId: Long): Result<Int> {
+        return try {
+            val token = tokenProvider.getTokenOrNull() ?: return Result.failure(Exception("인증 토큰이 없습니다"))
+
+            val response = noiseApiService.getTotalCount(
+                userId = userId,
+                authorization = "Bearer $token"
+            )
+
+            if (response.isSuccessful && response.body() != null) {
+                val totalCountResponse = response.body()!!
+
+                if (totalCountResponse.isSuccess) {
+                    Result.success(totalCountResponse.result.totalCount)
+                } else {
+                    Result.failure(Exception(totalCountResponse.message))
+                }
+            } else {
+                Result.failure(Exception("서버 응답 오류: ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    // [백엔드 API 연동] 이번 달 소음 기록 수 조회
+    override suspend fun getMonthlyCount(userId: Long, year: Int, month: Int): Result<Int> {
+        return try {
+            val token = tokenProvider.getTokenOrNull() ?: return Result.failure(Exception("인증 토큰이 없습니다"))
+
+            val response = noiseApiService.getMonthlyCount(
+                userId = userId,
+                year = year,
+                month = month,
+                authorization = "Bearer $token"
+            )
+
+            if (response.isSuccessful && response.body() != null) {
+                val monthlyCountResponse = response.body()!!
+
+                if (monthlyCountResponse.isSuccess) {
+                    Result.success(monthlyCountResponse.result.monthlyCount)
+                } else {
+                    Result.failure(Exception(monthlyCountResponse.message))
+                }
+            } else {
+                Result.failure(Exception("서버 응답 오류: ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    // [백엔드 API 연동] 전체 소음 기록 평균 dB 조회
+    override suspend fun getAverageDb(userId: Long): Result<Double> {
+        return try {
+            val token = tokenProvider.getTokenOrNull() ?: return Result.failure(Exception("인증 토큰이 없습니다"))
+
+            val response = noiseApiService.getAverageDb(
+                userId = userId,
+                authorization = "Bearer $token"
+            )
+
+            if (response.isSuccessful && response.body() != null) {
+                val averageDbResponse = response.body()!!
+
+                if (averageDbResponse.isSuccess) {
+                    Result.success(averageDbResponse.result.averageDb)
+                } else {
+                    Result.failure(Exception(averageDbResponse.message))
+                }
+            } else {
+                Result.failure(Exception("서버 응답 오류: ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    // [백엔드 API 연동] 소음 일기 수정
+    override suspend fun updateNoiseRecordApi(recordId: Long, noiseLog: NoiseLog): Result<NoiseLog> {
+        return try {
+            val token = tokenProvider.getTokenOrNull() ?: return Result.failure(Exception("인증 토큰이 없습니다"))
+
+            // NoiseLog를 API 요청 DTO로 변환
+            val request = com.kau.ttokttok.data.remote.dto.UpdateNoiseRecordRequest(
+                category = noiseLog.noiseType,
+                occuredAt = formatDateTimeForApi(noiseLog.measuredAt),
+                noiseGrade = convertToNoiseGrade(noiseLog.maxDecibel),
+                dbHigh = noiseLog.maxDecibel,
+                dbAvg = noiseLog.avgDecibel,
+                summary = noiseLog.memo
+            )
+
+            val response = noiseApiService.updateNoiseRecord(
+                recordId = recordId,
+                request = request,
+                authorization = "Bearer $token"
+            )
+
+            if (response.isSuccessful && response.body() != null) {
+                val updateResponse = response.body()!!
+
+                if (updateResponse.isSuccess) {
+                    // API 응답을 NoiseLog 도메인 모델로 변환
+                    val updatedLog = NoiseLog(
+                        id = updateResponse.result.noiseId.toString(),
+                        noiseType = updateResponse.result.category,
+                        maxDecibel = updateResponse.result.dbHigh,
+                        avgDecibel = updateResponse.result.dbAvg,
+                        memo = updateResponse.result.summary ?: "",
+                        measuredAt = parseDateTimeFromApi(updateResponse.result.occuredAt),
+                        hasReport = noiseLog.hasReport
+                    )
+                    Result.success(updatedLog)
+                } else {
+                    Result.failure(Exception(updateResponse.message))
+                }
+            } else {
+                Result.failure(Exception("서버 응답 오류: ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    // Date 객체를 API용 ISO 8601 형식으로 변환 (yyyy-MM-ddTHH:mm:ss)
+    private fun formatDateTimeForApi(date: Date): String {
+        val format = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", java.util.Locale.getDefault())
+        return format.format(date)
+    }
+
+    // API의 ISO 8601 형식 문자열을 Date 객체로 변환
+    private fun parseDateTimeFromApi(dateTimeStr: String): Date {
+        return try {
+            val format = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", java.util.Locale.getDefault())
+            format.parse(dateTimeStr) ?: Date()
+        } catch (e: Exception) {
+            Date()
+        }
+    }
+
+    // dB 값을 NoiseGrade로 변환
+    private fun convertToNoiseGrade(dbHigh: Double): String {
+        return when {
+            dbHigh >= 80 -> "VERY_LOUD"
+            dbHigh >= 60 -> "LOUD"
+            dbHigh >= 40 -> "NORMAL"
+            else -> "QUIET"
         }
     }
 }

--- a/app/src/main/java/com/kau/ttokttok/data/local/repository/NoiseLogRepositoryImpl.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/local/repository/NoiseLogRepositoryImpl.kt
@@ -261,6 +261,61 @@ class NoiseLogRepositoryImpl @Inject constructor(
         }
     }
 
+    // [백엔드 API 연동] 소음 일기 등록
+    override suspend fun createNoiseRecordApi(
+        occuredAt: String,
+        duration: Int,
+        dbHigh: Double,
+        dbAvg: Double,
+        category: String,
+        grade: String,
+        description: String?
+    ): Result<NoiseLog> {
+        return try {
+            val token = tokenProvider.getTokenOrNull() ?: return Result.failure(Exception("인증 토큰이 없습니다"))
+
+            // API 요청 DTO 생성
+            val request = com.kau.ttokttok.data.remote.dto.CreateNoiseRecordRequest(
+                occuredAt = occuredAt,
+                duration = duration,
+                dbHigh = dbHigh,
+                dbAvg = dbAvg,
+                category = category,
+                grade = grade,
+                description = description
+            )
+
+            val response = noiseApiService.createNoiseRecord(
+                request = request,
+                authorization = "Bearer $token"
+            )
+
+            if (response.isSuccessful && response.body() != null) {
+                val createResponse = response.body()!!
+
+                if (createResponse.isSuccess) {
+                    // API 응답을 NoiseLog 도메인 모델로 변환
+                    val createdLog = NoiseLog(
+                        id = createResponse.result.id.toString(),
+                        noiseType = createResponse.result.category,
+                        maxDecibel = createResponse.result.dbHigh,
+                        avgDecibel = createResponse.result.dbAvg,
+                        memo = createResponse.result.description ?: "",
+                        measuredAt = parseDateTimeFromApi(createResponse.result.occuredAt),
+                        hasReport = false
+                    )
+                    Result.success(createdLog)
+                } else {
+                    Result.failure(Exception(createResponse.message))
+                }
+            } else {
+                Result.failure(Exception("서버 응답 오류: ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     // [백엔드 API 연동] 소음 일기 수정
     override suspend fun updateNoiseRecordApi(recordId: Long, noiseLog: NoiseLog): Result<NoiseLog> {
         return try {
@@ -324,6 +379,32 @@ class NoiseLogRepositoryImpl @Inject constructor(
         }
     }
 
+    // [백엔드 API 연동] 소음 일기 삭제 (Hard Delete)
+    override suspend fun deleteNoiseRecordApi(recordId: Long): Result<Long> {
+        return try {
+            val token = tokenProvider.getTokenOrNull() ?: return Result.failure(Exception("인증 토큰이 없습니다"))
+
+            val response = noiseApiService.deleteNoiseRecord(
+                recordId = recordId,
+                authorization = "Bearer $token"
+            )
+
+            if (response.isSuccessful && response.body() != null) {
+                val deleteResponse = response.body()!!
+
+                if (deleteResponse.isSuccess) {
+                    Result.success(deleteResponse.result.recordId)
+                } else {
+                    Result.failure(Exception(deleteResponse.message))
+                }
+            } else {
+                Result.failure(Exception("서버 응답 오류: ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     // dB 값을 NoiseGrade로 변환
     private fun convertToNoiseGrade(dbHigh: Double): String {
         return when {
@@ -331,6 +412,32 @@ class NoiseLogRepositoryImpl @Inject constructor(
             dbHigh >= 60 -> "LOUD"
             dbHigh >= 40 -> "NORMAL"
             else -> "QUIET"
+        }
+    }
+
+    // [백엔드 API 연동] 소음 기록 1개 데이터를 '소음현황' 페이지로 전송
+    override suspend fun sendNoiseRecordApi(recordId: Long): Result<Long> {
+        return try {
+            val token = tokenProvider.getTokenOrNull() ?: return Result.failure(Exception("인증 토큰이 없습니다"))
+
+            val response = noiseApiService.sendNoiseRecord(
+                recordId = recordId,
+                authorization = "Bearer $token"
+            )
+
+            if (response.isSuccessful && response.body() != null) {
+                val sendResponse = response.body()!!
+
+                if (sendResponse.isSuccess) {
+                    Result.success(sendResponse.result)
+                } else {
+                    Result.failure(Exception(sendResponse.message))
+                }
+            } else {
+                Result.failure(Exception("서버 응답 오류: ${response.code()}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 }

--- a/app/src/main/java/com/kau/ttokttok/data/remote/api/NoiseApiService.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/api/NoiseApiService.kt
@@ -1,0 +1,116 @@
+package com.kau.ttokttok.data.remote.api
+
+import com.kau.ttokttok.data.remote.dto.AverageDbResponse
+import com.kau.ttokttok.data.remote.dto.CalendarResponse
+import com.kau.ttokttok.data.remote.dto.MonthlyCountResponse
+import com.kau.ttokttok.data.remote.dto.NoiseRecordsByDateResponse
+import com.kau.ttokttok.data.remote.dto.TotalCountResponse
+import com.kau.ttokttok.data.remote.dto.UpdateNoiseRecordRequest
+import com.kau.ttokttok.data.remote.dto.UpdateNoiseRecordResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.PATCH
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+/**
+ * 소음 일기 관련 API 서비스
+ */
+interface NoiseApiService {
+
+    /**
+     * 캘린더 월별 소음 일기 조회
+     * GET /noise/records/calendar/{userId}
+     *
+     * @param userId 회원 고유 ID
+     * @param year 조회할 연도 (예: 2025)
+     * @param month 조회할 월 (예: 10)
+     * @param authorization JWT 토큰 ("Bearer {token}")
+     * @return 해당 월의 모든 날짜와 소음 일기 존재 여부
+     */
+    @GET("noise/records/calendar/{userId}")
+    suspend fun getCalendarData(
+        @Path("userId") userId: Long,
+        @Query("year") year: Int,
+        @Query("month") month: Int,
+        @Header("Authorization") authorization: String
+    ): Response<CalendarResponse>
+
+    /**
+     * 날짜별 소음 기록 상세 조회
+     * GET /noise/records/calendar?date=2025-10-27
+     *
+     * @param date 조회할 날짜 (yyyy-MM-dd 형식)
+     * @param authorization JWT 토큰 ("Bearer {token}")
+     * @return 해당 날짜의 소음 기록 목록 (생성 시간 순 정렬)
+     */
+    @GET("noise/records/calendar")
+    suspend fun getNoiseRecordsByDate(
+        @Query("date") date: String,
+        @Header("Authorization") authorization: String
+    ): Response<NoiseRecordsByDateResponse>
+
+    /**
+     * 총 소음 기록 수 조회
+     * GET /noise/records/total-count/{userId}
+     *
+     * @param userId 조회할 사용자의 ID
+     * @param authorization JWT 토큰 ("Bearer {token}")
+     * @return 사용자의 전체 소음 기록 개수
+     */
+    @GET("noise/records/total-count/{userId}")
+    suspend fun getTotalCount(
+        @Path("userId") userId: Long,
+        @Header("Authorization") authorization: String
+    ): Response<TotalCountResponse>
+
+    /**
+     * 이번 달 소음 기록 수 조회
+     * GET /noise/records/monthly-count/{userId}
+     *
+     * @param userId 조회할 사용자의 ID
+     * @param year 조회할 연도
+     * @param month 조회할 월
+     * @param authorization JWT 토큰 ("Bearer {token}")
+     * @return 해당 월의 소음 기록 개수
+     */
+    @GET("noise/records/monthly-count/{userId}")
+    suspend fun getMonthlyCount(
+        @Path("userId") userId: Long,
+        @Query("year") year: Int,
+        @Query("month") month: Int,
+        @Header("Authorization") authorization: String
+    ): Response<MonthlyCountResponse>
+
+    /**
+     * 전체 소음 기록 평균 dB 조회
+     * GET /noise/records/average-db/{userId}
+     *
+     * @param userId 조회할 사용자의 ID
+     * @param authorization JWT 토큰 ("Bearer {token}")
+     * @return 사용자의 전체 소음 기록 평균 dB
+     */
+    @GET("noise/records/average-db/{userId}")
+    suspend fun getAverageDb(
+        @Path("userId") userId: Long,
+        @Header("Authorization") authorization: String
+    ): Response<AverageDbResponse>
+
+    /**
+     * 소음 일기 수정
+     * PATCH /noise/records/{recordId}
+     *
+     * @param recordId 수정할 소음 기록의 고유 ID
+     * @param request 수정할 소음 기록 데이터
+     * @param authorization JWT 토큰 ("Bearer {token}")
+     * @return 수정된 소음 기록 정보
+     */
+    @PATCH("noise/records/{recordId}")
+    suspend fun updateNoiseRecord(
+        @Path("recordId") recordId: Long,
+        @Body request: UpdateNoiseRecordRequest,
+        @Header("Authorization") authorization: String
+    ): Response<UpdateNoiseRecordResponse>
+}

--- a/app/src/main/java/com/kau/ttokttok/data/remote/api/NoiseApiService.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/api/NoiseApiService.kt
@@ -2,16 +2,22 @@ package com.kau.ttokttok.data.remote.api
 
 import com.kau.ttokttok.data.remote.dto.AverageDbResponse
 import com.kau.ttokttok.data.remote.dto.CalendarResponse
+import com.kau.ttokttok.data.remote.dto.CreateNoiseRecordRequest
+import com.kau.ttokttok.data.remote.dto.CreateNoiseRecordResponse
+import com.kau.ttokttok.data.remote.dto.DeleteNoiseRecordResponse
 import com.kau.ttokttok.data.remote.dto.MonthlyCountResponse
 import com.kau.ttokttok.data.remote.dto.NoiseRecordsByDateResponse
+import com.kau.ttokttok.data.remote.dto.SendNoiseRecordResponse
 import com.kau.ttokttok.data.remote.dto.TotalCountResponse
 import com.kau.ttokttok.data.remote.dto.UpdateNoiseRecordRequest
 import com.kau.ttokttok.data.remote.dto.UpdateNoiseRecordResponse
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.PATCH
+import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -99,6 +105,20 @@ interface NoiseApiService {
     ): Response<AverageDbResponse>
 
     /**
+     * 소음 일기 등록
+     * POST /noise/records
+     *
+     * @param request 소음 기록 생성 데이터
+     * @param authorization JWT 토큰 ("Bearer {token}")
+     * @return 생성된 소음 기록 정보
+     */
+    @POST("noise/records")
+    suspend fun createNoiseRecord(
+        @Body request: CreateNoiseRecordRequest,
+        @Header("Authorization") authorization: String
+    ): Response<CreateNoiseRecordResponse>
+
+    /**
      * 소음 일기 수정
      * PATCH /noise/records/{recordId}
      *
@@ -113,4 +133,32 @@ interface NoiseApiService {
         @Body request: UpdateNoiseRecordRequest,
         @Header("Authorization") authorization: String
     ): Response<UpdateNoiseRecordResponse>
+
+    /**
+     * 소음 일기 삭제 (Hard Delete)
+     * DELETE /noise/records/{recordId}
+     *
+     * @param recordId 삭제할 소음 기록의 고유 ID
+     * @param authorization JWT 토큰 ("Bearer {token}")
+     * @return 삭제된 소음 기록 ID
+     */
+    @DELETE("noise/records/{recordId}")
+    suspend fun deleteNoiseRecord(
+        @Path("recordId") recordId: Long,
+        @Header("Authorization") authorization: String
+    ): Response<DeleteNoiseRecordResponse>
+
+    /**
+     * 소음 기록 1개 데이터를 '소음현황' 페이지로 전송
+     * POST /noise/records/{recordId}/send
+     *
+     * @param recordId 전송할 소음 기록의 고유 ID
+     * @param authorization JWT 토큰 ("Bearer {token}")
+     * @return 전송된 소음 기록 ID
+     */
+    @POST("noise/records/{recordId}/send")
+    suspend fun sendNoiseRecord(
+        @Path("recordId") recordId: Long,
+        @Header("Authorization") authorization: String
+    ): Response<SendNoiseRecordResponse>
 }

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/CalendarResponse.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/CalendarResponse.kt
@@ -1,0 +1,212 @@
+package com.kau.ttokttok.data.remote.dto
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+/**
+ * 캘린더 API 응답 모델
+ * GET /noise/records/calendar/{userId} (월별 조회)
+ */
+@JsonClass(generateAdapter = true)
+data class CalendarResponse(
+    @Json(name = "result")
+    val result: CalendarResult,
+    @Json(name = "code")
+    val code: String,
+    @Json(name = "message")
+    val message: String,
+    @Json(name = "isSuccess")
+    val isSuccess: Boolean
+)
+
+@JsonClass(generateAdapter = true)
+data class CalendarResult(
+    @Json(name = "month")
+    val month: Int,
+    @Json(name = "data")
+    val data: List<CalendarDayData>,
+    @Json(name = "year")
+    val year: Int,
+    @Json(name = "userId")
+    val userId: Long
+)
+
+@JsonClass(generateAdapter = true)
+data class CalendarDayData(
+    @Json(name = "date")
+    val date: String, // "2025-10-01" 형식
+    @Json(name = "hasNoiseLog")
+    val hasNoiseLog: Boolean
+)
+
+/**
+ * 날짜별 소음 기록 조회 API 응답 모델
+ * GET /noise/records/calendar?date=2025-10-27
+ */
+@JsonClass(generateAdapter = true)
+data class NoiseRecordsByDateResponse(
+    @Json(name = "result")
+    val result: NoiseRecordsByDateResult,
+    @Json(name = "code")
+    val code: String,
+    @Json(name = "message")
+    val message: String,
+    @Json(name = "isSuccess")
+    val isSuccess: Boolean
+)
+
+@JsonClass(generateAdapter = true)
+data class NoiseRecordsByDateResult(
+    @Json(name = "date")
+    val date: String,
+    @Json(name = "records")
+    val records: List<NoiseRecordDetail>,
+    @Json(name = "userId")
+    val userId: Long
+)
+
+@JsonClass(generateAdapter = true)
+data class NoiseRecordDetail(
+    @Json(name = "recordId")
+    val recordId: Long,
+    @Json(name = "logDate")
+    val logDate: String,
+    @Json(name = "logTime")
+    val logTime: String,
+    @Json(name = "noiseType")
+    val noiseType: String,
+    @Json(name = "noiseLevel")
+    val noiseLevel: Int,
+    @Json(name = "memo")
+    val memo: String?,
+    @Json(name = "createdAt")
+    val createdAt: String,
+    @Json(name = "modifiedAt")
+    val modifiedAt: String
+)
+
+/**
+ * 총 소음 기록 수 조회 API 응답 모델
+ * GET /noise/records/total-count/{userId}
+ */
+@JsonClass(generateAdapter = true)
+data class TotalCountResponse(
+    @Json(name = "result")
+    val result: TotalCountResult,
+    @Json(name = "code")
+    val code: String,
+    @Json(name = "message")
+    val message: String,
+    @Json(name = "isSuccess")
+    val isSuccess: Boolean
+)
+
+@JsonClass(generateAdapter = true)
+data class TotalCountResult(
+    @Json(name = "totalCount")
+    val totalCount: Int
+)
+
+/**
+ * 이번 달 소음 기록 수 조회 API 응답 모델
+ * GET /noise/records/monthly-count/{userId}
+ */
+@JsonClass(generateAdapter = true)
+data class MonthlyCountResponse(
+    @Json(name = "result")
+    val result: MonthlyCountResult,
+    @Json(name = "code")
+    val code: String,
+    @Json(name = "message")
+    val message: String,
+    @Json(name = "isSuccess")
+    val isSuccess: Boolean
+)
+
+@JsonClass(generateAdapter = true)
+data class MonthlyCountResult(
+    @Json(name = "month")
+    val month: Int,
+    @Json(name = "monthlyCount")
+    val monthlyCount: Int,
+    @Json(name = "year")
+    val year: Int
+)
+
+/**
+ * 전체 소음 기록 평균 dB 조회 API 응답 모델
+ * GET /noise/records/average-db/{userId}
+ */
+@JsonClass(generateAdapter = true)
+data class AverageDbResponse(
+    @Json(name = "result")
+    val result: AverageDbResult,
+    @Json(name = "code")
+    val code: String,
+    @Json(name = "message")
+    val message: String,
+    @Json(name = "isSuccess")
+    val isSuccess: Boolean
+)
+
+@JsonClass(generateAdapter = true)
+data class AverageDbResult(
+    @Json(name = "averageDb")
+    val averageDb: Double
+)
+
+/**
+ * 소음 일기 수정 API 요청 모델
+ * PATCH /noise/records/{recordId}
+ */
+@JsonClass(generateAdapter = true)
+data class UpdateNoiseRecordRequest(
+    @Json(name = "category")
+    val category: String,
+    @Json(name = "occuredAt")
+    val occuredAt: String, // "2025-11-08T01:34:17" 형식
+    @Json(name = "noiseGrade")
+    val noiseGrade: String,
+    @Json(name = "dbHigh")
+    val dbHigh: Double,
+    @Json(name = "dbAvg")
+    val dbAvg: Double,
+    @Json(name = "summary")
+    val summary: String?
+)
+
+/**
+ * 소음 일기 수정 API 응답 모델
+ * PATCH /noise/records/{recordId}
+ */
+@JsonClass(generateAdapter = true)
+data class UpdateNoiseRecordResponse(
+    @Json(name = "result")
+    val result: UpdateNoiseRecordResult,
+    @Json(name = "code")
+    val code: String,
+    @Json(name = "message")
+    val message: String,
+    @Json(name = "isSuccess")
+    val isSuccess: Boolean
+)
+
+@JsonClass(generateAdapter = true)
+data class UpdateNoiseRecordResult(
+    @Json(name = "noiseId")
+    val noiseId: Long,
+    @Json(name = "category")
+    val category: String,
+    @Json(name = "occuredAt")
+    val occuredAt: String,
+    @Json(name = "noiseGrade")
+    val noiseGrade: String,
+    @Json(name = "dbHigh")
+    val dbHigh: Double,
+    @Json(name = "dbAvg")
+    val dbAvg: Double,
+    @Json(name = "summary")
+    val summary: String?,
+    @Json(name = "updatedAt")
+    val updatedAt: String
+)

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/CalendarResponse.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/CalendarResponse.kt
@@ -156,6 +156,92 @@ data class AverageDbResult(
 )
 
 /**
+ * 소음 일기 등록 API 요청 모델
+ * POST /noise/records
+ */
+@JsonClass(generateAdapter = true)
+data class CreateNoiseRecordRequest(
+    @Json(name = "occuredAt")
+    val occuredAt: String, // "2025-11-09T11:32:57.272Z" 형식
+    @Json(name = "duration")
+    val duration: Int, // 측정 소요 시간(녹음 duration)
+    @Json(name = "dbHigh")
+    val dbHigh: Double, // 최대 데시벨
+    @Json(name = "dbAvg")
+    val dbAvg: Double, // 평균 데시벨
+    @Json(name = "category")
+    val category: String, // FOOTSTEPS, HAMMERING, FURNITURE, MUSIC, UNKNOWN
+    @Json(name = "grade")
+    val grade: String, // QUIET, NORMAL, LOUD
+    @Json(name = "description")
+    val description: String? // 소음일기 내용
+)
+
+/**
+ * 소음 일기 등록 API 응답 모델
+ * POST /noise/records
+ */
+@JsonClass(generateAdapter = true)
+data class CreateNoiseRecordResponse(
+    @Json(name = "result")
+    val result: CreateNoiseRecordResult,
+    @Json(name = "code")
+    val code: String,
+    @Json(name = "message")
+    val message: String,
+    @Json(name = "isSuccess")
+    val isSuccess: Boolean
+)
+
+@JsonClass(generateAdapter = true)
+data class CreateNoiseRecordResult(
+    @Json(name = "id")
+    val id: Long,
+    @Json(name = "userId")
+    val userId: Long,
+    @Json(name = "duration")
+    val duration: Int,
+    @Json(name = "dbHigh")
+    val dbHigh: Double,
+    @Json(name = "dbAvg")
+    val dbAvg: Double,
+    @Json(name = "category")
+    val category: String,
+    @Json(name = "grade")
+    val grade: String,
+    @Json(name = "description")
+    val description: String?,
+    @Json(name = "summary")
+    val summary: String?,
+    @Json(name = "occuredAt")
+    val occuredAt: String,
+    @Json(name = "updateAt")
+    val updateAt: String
+)
+
+/**
+ * 소음 일기 삭제 API 응답 모델
+ * DELETE /noise/records/{recordId}
+ */
+@JsonClass(generateAdapter = true)
+data class DeleteNoiseRecordResponse(
+    @Json(name = "result")
+    val result: DeleteNoiseRecordResult,
+    @Json(name = "code")
+    val code: String,
+    @Json(name = "message")
+    val message: String,
+    @Json(name = "isSuccess")
+    val isSuccess: Boolean
+)
+
+@JsonClass(generateAdapter = true)
+data class DeleteNoiseRecordResult(
+    @Json(name = "recordId")
+    val recordId: Long
+)
+
+/**
  * 소음 일기 수정 API 요청 모델
  * PATCH /noise/records/{recordId}
  */
@@ -210,3 +296,20 @@ data class UpdateNoiseRecordResult(
     @Json(name = "updatedAt")
     val updatedAt: String
 )
+
+/**
+ * 소음 기록 전송 API 응답 모델
+ * POST /noise/records/{recordId}/send
+ */
+@JsonClass(generateAdapter = true)
+data class SendNoiseRecordResponse(
+    @Json(name = "result")
+    val result: Long, // 전송된 소음 기록의 ID
+    @Json(name = "code")
+    val code: String,
+    @Json(name = "message")
+    val message: String,
+    @Json(name = "isSuccess")
+    val isSuccess: Boolean
+)
+

--- a/app/src/main/java/com/kau/ttokttok/domain/repository/NoiseLogRepository.kt
+++ b/app/src/main/java/com/kau/ttokttok/domain/repository/NoiseLogRepository.kt
@@ -84,6 +84,27 @@ interface NoiseLogRepository {
     ): Result<Double>
 
     /**
+     * 소음 일기 등록 (API 연동)
+     * @param occuredAt 소음 발생 시간 (ISO 8601 형식)
+     * @param duration 측정 소요 시간(녹음 duration)
+     * @param dbHigh 최대 데시벨
+     * @param dbAvg 평균 데시벨
+     * @param category 소음 카테고리 (FOOTSTEPS, HAMMERING, FURNITURE, MUSIC, UNKNOWN)
+     * @param grade 소음 등급 (QUIET, NORMAL, LOUD)
+     * @param description 소음일기 내용
+     * @return 생성된 소음 일기
+     */
+    suspend fun createNoiseRecordApi(
+        occuredAt: String,
+        duration: Int,
+        dbHigh: Double,
+        dbAvg: Double,
+        category: String,
+        grade: String,
+        description: String?
+    ): Result<NoiseLog>
+
+    /**
      * 소음 일기 수정 (API 연동)
      * @param recordId 수정할 소음 기록의 고유 ID
      * @param noiseLog 수정할 소음 일기 데이터
@@ -93,4 +114,22 @@ interface NoiseLogRepository {
         recordId: Long,
         noiseLog: NoiseLog
     ): Result<NoiseLog>
+
+    /**
+     * 소음 일기 삭제 (API 연동 - Hard Delete)
+     * @param recordId 삭제할 소음 기록의 고유 ID
+     * @return 삭제된 소음 기록 ID
+     */
+    suspend fun deleteNoiseRecordApi(
+        recordId: Long
+    ): Result<Long>
+
+    /**
+     * 소음 기록 1개 데이터를 '소음현황' 페이지로 전송 (API 연동)
+     * @param recordId 전송할 소음 기록의 고유 ID
+     * @return 전송된 소음 기록 ID
+     */
+    suspend fun sendNoiseRecordApi(
+        recordId: Long
+    ): Result<Long>
 }

--- a/app/src/main/java/com/kau/ttokttok/domain/repository/NoiseLogRepository.kt
+++ b/app/src/main/java/com/kau/ttokttok/domain/repository/NoiseLogRepository.kt
@@ -29,4 +29,68 @@ interface NoiseLogRepository {
     // TODO: [백엔드 연동] 서버에서 날짜 범위로 쿼리
     // 날짜별 일기 가져오기
     suspend fun getNoiseLogsByDate(date: Date): Result<List<NoiseLog>>
+
+    /**
+     * 캘린더 월별 데이터 조회
+     * @param userId 회원 고유 ID
+     * @param year 조회할 연도
+     * @param month 조회할 월
+     * @return 해당 월의 날짜별 소음 일기 존재 여부 Map (날짜 -> hasNoiseLog)
+     */
+    suspend fun getCalendarData(
+        userId: Long,
+        year: Int,
+        month: Int
+    ): Result<Map<String, Boolean>>
+
+    /**
+     * 날짜별 소음 기록 상세 조회
+     * @param date 조회할 날짜 (yyyy-MM-dd 형식)
+     * @return 해당 날짜의 소음 기록 목록 (생성 시간 순 정렬)
+     */
+    suspend fun getNoiseRecordsByDate(
+        date: String
+    ): Result<List<NoiseLog>>
+
+    /**
+     * 총 소음 기록 수 조회
+     * @param userId 조회할 사용자의 ID
+     * @return 사용자의 전체 소음 기록 개수
+     */
+    suspend fun getTotalCount(
+        userId: Long
+    ): Result<Int>
+
+    /**
+     * 이번 달 소음 기록 수 조회
+     * @param userId 조회할 사용자의 ID
+     * @param year 조회할 연도
+     * @param month 조회할 월
+     * @return 해당 월의 소음 기록 개수
+     */
+    suspend fun getMonthlyCount(
+        userId: Long,
+        year: Int,
+        month: Int
+    ): Result<Int>
+
+    /**
+     * 전체 소음 기록 평균 dB 조회
+     * @param userId 조회할 사용자의 ID
+     * @return 사용자의 전체 소음 기록 평균 dB
+     */
+    suspend fun getAverageDb(
+        userId: Long
+    ): Result<Double>
+
+    /**
+     * 소음 일기 수정 (API 연동)
+     * @param recordId 수정할 소음 기록의 고유 ID
+     * @param noiseLog 수정할 소음 일기 데이터
+     * @return 수정된 소음 일기
+     */
+    suspend fun updateNoiseRecordApi(
+        recordId: Long,
+        noiseLog: NoiseLog
+    ): Result<NoiseLog>
 }

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogAdapter.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogAdapter.kt
@@ -12,8 +12,12 @@ import com.kau.ttokttok.domain.model.NoiseLog
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-// TODO: [백엔드 연동] 향후 이미지/오디오 첨부 기능 추가 시 Glide/Coil 라이브러리 사용
-// TODO: [백엔드 연동] 이미지 URL: log.imageUrls?.let { urls -> loadImages(urls) }
+/**
+ * 소음 일기 목록 어댑터
+ * - 일기 아이템 표시 및 선택 관리
+ * - 수정/삭제 메뉴 제공
+ * - 리포트 생성을 위한 체크박스 관리
+ */
 class NoiseLogAdapter(
     private val onDeleteClick: (NoiseLog) -> Unit,
     private val onEditClick: (NoiseLog) -> Unit,
@@ -55,9 +59,7 @@ class NoiseLogAdapter(
         fun bind(log: NoiseLog) {
             binding.tvDate.text = dateFormat.format(log.measuredAt)
 
-            // TODO: [백엔드 연동] hasReport는 서버에서 관리하는 상태
-            // TODO: [백엔드 연동] 리포트 생성 후 서버가 NoiseLog.hasReport를 true로 업데이트
-            // TODO: [백엔드 연동] 리포트 ID도 함께 저장하여 리포트 상세 화면으로 이동 가능하게 구현
+            // 리포트 생성 상태 표시
             binding.tvReportStatus.visibility = if (log.hasReport) {
                 binding.tvReportStatus.text = "📄 리포트 생성됨"
                 android.view.View.VISIBLE
@@ -89,12 +91,11 @@ class NoiseLogAdapter(
             binding.cbSelect.setOnCheckedChangeListener(null)
 
             if (log.hasReport) {
-                // TODO: [백엔드 연동] 리포트 생성 여부는 서버에서 관리
-                // TODO: [백엔드 연동] 이미 리포트 생성된 로그는 재생성 불가 (서버 정책)
+                // 이미 리포트 생성된 로그는 재선택 불가
                 binding.cbSelect.isChecked = true
                 binding.cbSelect.isEnabled = false
             } else {
-                // TODO: [백엔드 연동] 선택된 로그들로 리포트 생성 (여러 로그를 하나의 리포트로)
+                // 리포트 미생성 로그만 선택 가능
                 binding.cbSelect.isEnabled = true
                 binding.cbSelect.isChecked = log.id in selectedItems
 
@@ -134,9 +135,9 @@ class NoiseLogAdapter(
         }
 
         private fun getNoiseLevel(db: Double): Pair<String, Int> = when {
-            db >= 85.0 -> "매우 시끄러움" to R.drawable.bg_level_red
-            db >= 70.0 -> "시끄러움" to R.drawable.bg_level_orange
-            db >= 50.0 -> "보통" to R.drawable.bg_level_yellow
+            db >= 70.0 -> "매우 시끄러움" to R.drawable.bg_level_red
+            db >= 55.0 -> "시끄러움" to R.drawable.bg_level_orange
+            db >= 40.0 -> "보통" to R.drawable.bg_level_yellow
             else -> "조용함" to R.drawable.bg_level_green
         }
     }

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogFormFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogFormFragment.kt
@@ -217,7 +217,31 @@ class NoiseLogFormFragment : Fragment() {
                 Toast.makeText(requireContext(), "소음 일기가 수정되었습니다", Toast.LENGTH_SHORT).show()
             }
         } else {
-            viewModel.saveLog(noiseLog)
+            // 신규 등록: 실제 API 호출
+            val occuredAt = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault()).apply {
+                timeZone = java.util.TimeZone.getTimeZone("UTC")
+            }.format(measuredAt)
+
+            // 소음 카테고리 매핑 (한글 -> 영문)
+            val category = mapNoiseTypeToCategory(selectedNoiseType!!)
+
+            // 소음 등급 결정
+            val grade = when {
+                maxDb >= 80 -> "LOUD"
+                maxDb >= 60 -> "NORMAL"
+                else -> "QUIET"
+            }
+
+            // API 호출
+            viewModel.createNoiseRecordApi(
+                occuredAt = occuredAt,
+                duration = duration.toInt(),
+                dbHigh = maxDb,
+                dbAvg = avgDb,
+                category = category,
+                grade = grade,
+                description = binding.etMemo.text.toString()
+            )
             Toast.makeText(requireContext(), "소음 일기가 저장되었습니다", Toast.LENGTH_SHORT).show()
         }
 
@@ -227,6 +251,17 @@ class NoiseLogFormFragment : Fragment() {
         // 캘린더 화면(NoiseLogFragment)으로 이동
         // popBackStack 대신 명시적으로 NoiseLogFragment로 이동
         findNavController().navigate(R.id.noiseLogFragment)
+    }
+
+    /**
+     * 한글 소음 타입을 API 카테고리로 매핑
+     */
+    private fun mapNoiseTypeToCategory(noiseType: String): String = when (noiseType) {
+        "발걸음", "아이들 뛰는 소리" -> "FOOTSTEPS"
+        "망치질" -> "HAMMERING"
+        "가구 끄는 소리" -> "FURNITURE"
+        "음악 소리" -> "MUSIC"
+        else -> "UNKNOWN"
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogFormFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogFormFragment.kt
@@ -27,7 +27,7 @@ class NoiseLogFormFragment : Fragment() {
     private val viewModel: NoiseLogViewModel by activityViewModels()
 
     // 측정 데이터
-    private var logId: String? = null // 수정 모드일 때 로그 ID
+    private var logId: Long? = null // 수정 모드일 때 로그 ID (recordId)
     private var isEditMode = false // 수정 모드 여부
     private var maxDb = 0.0
     private var avgDb = 0.0
@@ -40,7 +40,7 @@ class NoiseLogFormFragment : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         arguments?.let {
-            logId = it.getString(ARG_LOG_ID)
+            logId = it.getLong(ARG_LOG_ID, -1L).takeIf { id -> id != -1L }
             isEditMode = logId != null
             maxDb = it.getDouble(ARG_MAX_DB, 0.0)
             avgDb = it.getDouble(ARG_AVG_DB, 0.0)
@@ -158,12 +158,13 @@ class NoiseLogFormFragment : Fragment() {
     }
 
     private fun getSuggestedNoiseType(avgDb: Double): String = when {
-        avgDb >= 60.0 -> "망치질"
-        avgDb >= 50.0 -> "가구 끄는 소리"
-        avgDb >= 45.0 -> "아이들 뛰는 소리"
-        avgDb >= 40.0 -> "발걸음"
-        avgDb >= 35.0 -> "음악 소리"
-        else -> "청소기 소리"
+        avgDb >= 70.0 -> "망치질"           // 매우 시끄러움 (70dB 이상)
+        avgDb >= 60.0 -> "아이들 뛰는 소리"  // 시끄러움
+        avgDb >= 55.0 -> "가구 끄는 소리"    // 시끄러움
+        avgDb >= 50.0 -> "청소기 소리"       // 보통
+        avgDb >= 45.0 -> "음악 소리"         // 보통
+        avgDb >= 40.0 -> "발걸음"            // 보통
+        else -> "기타"                       // 조용함 (40dB 미만)
     }
 
     private fun validateInput(): Boolean {
@@ -181,24 +182,11 @@ class NoiseLogFormFragment : Fragment() {
         return true
     }
 
-    // AI 일기 생성 - AI 서버에 요청하여 자동 일기 생성
+    // AI 일기 생성 - 미구현 (서버 AI API 필요)
     private fun generateAiDiary() {
         val memo = binding.etMemo.text.toString()
 
-        // TODO: [백엔드 연동] AI API 호출 (POST /api/ai/generate-diary)
-        // TODO: [백엔드 연동] 요청 본문: {
-        //   noiseType: selectedNoiseType,
-        //   maxDb: maxDb,
-        //   avgDb: avgDb,
-        //   duration: duration,
-        //   userMemo: memo,
-        //   timestamp: measuredAt
-        // }
-        // TODO: [백엔드 연동] 응답: { generatedText: string, confidence: number }
-        // TODO: [백엔드 연동] 로딩 상태 표시 (ProgressBar 또는 Shimmer 효과)
-        // TODO: [백엔드 연동] viewModel.generateAiDiary(...).collect { result -> ... }
-
-        // 임시 AI 일기 생성 로직 (실제로는 서버 응답 사용)
+        // 임시 AI 일기 생성 로직 (실제로는 서버 AI API 사용)
         val aiGeneratedDiary = buildString {
             append("[$selectedNoiseType] $memo\n\n")
             append("측정 시간: ${duration}초 동안 ")
@@ -209,13 +197,11 @@ class NoiseLogFormFragment : Fragment() {
 
         binding.etMemo.setText(aiGeneratedDiary)
         Toast.makeText(requireContext(), "AI 일기가 생성되었습니다", Toast.LENGTH_SHORT).show()
-        // TODO: [백엔드 연동] AI 생성 실패 시 에러 메시지 표시 및 재시도 옵션
-        // TODO: [백엔드 연동] 타임아웃(30초) 설정 및 처리
     }
 
     private fun saveNoiseLog() {
         val noiseLog = NoiseLog(
-            id = logId, // 수정 모드일 때 기존 ID 유지, 신규일 때 null
+            id = logId?.toString(), // NoiseLog의 id는 String 타입
             noiseType = selectedNoiseType!!,
             maxDecibel = maxDb,
             avgDecibel = avgDb,
@@ -224,33 +210,23 @@ class NoiseLogFormFragment : Fragment() {
             hasReport = false
         )
 
-        // TODO: [백엔드 연동] 저장 전 검증 (메모 최소 길이, 욕설 필터링 등)
-        // TODO: [백엔드 연동] ViewModel을 통해 Repository의 save/update 함수 호출
-        // TODO: [백엔드 연동] 성공/실패 여부를 StateFlow로 관찰하여 UI 업데이트
-
         if (isEditMode) {
-            viewModel.updateLog(noiseLog)
-            Toast.makeText(requireContext(), "소음 일기가 수정되었습니다", Toast.LENGTH_SHORT).show()
-            // TODO: [백엔드 연동] 수정 성공 응답 확인 후 화면 전환
+            // API 연동: recordId와 noiseLog를 별도로 전달
+            logId?.let { recordId ->
+                viewModel.updateLogApi(recordId, noiseLog)
+                Toast.makeText(requireContext(), "소음 일기가 수정되었습니다", Toast.LENGTH_SHORT).show()
+            }
         } else {
             viewModel.saveLog(noiseLog)
             Toast.makeText(requireContext(), "소음 일기가 저장되었습니다", Toast.LENGTH_SHORT).show()
-            // TODO: [백엔드 연동] 저장 성공 응답에서 서버 생성 ID 받아서 사용
         }
-
-        // TODO: [백엔드 연동] 저장 실패 시 재시도 다이얼로그 표시
-        // TODO: [백엔드 연동] 네트워크 오류 시 로컬에 임시 저장 후 나중에 동기화
 
         // 저장한 날짜를 선택하여 해당 날짜의 로그를 표시
         viewModel.selectDate(measuredAt)
 
-        // 캘린더 화면으로 돌아가기
-        if (isEditMode) {
-            findNavController().popBackStack()
-        } else {
-            findNavController().popBackStack()
-            findNavController().popBackStack()
-        }
+        // 캘린더 화면(NoiseLogFragment)으로 이동
+        // popBackStack 대신 명시적으로 NoiseLogFragment로 이동
+        findNavController().navigate(R.id.noiseLogFragment)
     }
 
     override fun onDestroyView() {
@@ -282,7 +258,8 @@ class NoiseLogFormFragment : Fragment() {
         fun newInstanceForEdit(log: NoiseLog) =
             NoiseLogFormFragment().apply {
                 arguments = Bundle().apply {
-                    putString(ARG_LOG_ID, log.id)
+                    // log.id를 Long으로 변환하여 전달
+                    log.id?.toLongOrNull()?.let { putLong(ARG_LOG_ID, it) }
                     putString(ARG_NOISE_TYPE, log.noiseType)
                     putString(ARG_MEMO, log.memo)
                     putDouble(ARG_MAX_DB, log.maxDecibel)

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogFragment.kt
@@ -144,7 +144,14 @@ class NoiseLogFragment : Fragment() {
      */
     private fun setupRecyclerView() {
         adapter = NoiseLogAdapter(
-            onDeleteClick = { log -> viewModel.deleteLog(log.id!!) },
+            onDeleteClick = { log ->
+                // API를 통한 삭제 (recordId를 Long으로 변환)
+                log.id?.toLongOrNull()?.let { recordId ->
+                    viewModel.deleteNoiseRecordApi(recordId)
+                } ?: run {
+                    Toast.makeText(requireContext(), "잘못된 기록 ID입니다", Toast.LENGTH_SHORT).show()
+                }
+            },
             onEditClick = { log ->
                 // 수정 화면으로 이동 (Navigator 방식)
                 val bundle = Bundle().apply {

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogFragment.kt
@@ -117,6 +117,21 @@ class NoiseLogFragment : Fragment() {
         }.time
         viewModel.selectDate(today)
 
+        // TODO: 실제 userId는 로그인한 사용자의 ID로 교체해야 함
+        val userId = 3L // 테스트용 userId (API 명세서 예시)
+
+        // 캘린더 API 호출 - 현재 월의 데이터 로드
+        viewModel.loadCurrentMonthCalendar(userId)
+
+        // 총 소음 기록 수 API 호출
+        viewModel.loadTotalCount(userId)
+
+        // 이번 달 소음 기록 수 API 호출
+        viewModel.loadMonthlyCount(userId)
+
+        // 전체 평균 dB API 호출
+        viewModel.loadAverageDb(userId)
+
         // FAB 애니메이션 시작 (10초 후 첫 실행)
         handler.postDelayed(flipAnimationRunnable, 10000)
     }
@@ -157,6 +172,13 @@ class NoiseLogFragment : Fragment() {
      */
     private fun setupCalendar() {
         binding.calendarView.setOnDateChangeListener { _, year, month, dayOfMonth ->
+            // yyyy-MM-dd 형식으로 날짜 문자열 생성
+            val dateStr = String.format("%04d-%02d-%02d", year, month + 1, dayOfMonth)
+
+            // 새로운 API 호출: 날짜별 소음 기록 상세 조회
+            viewModel.loadNoiseRecordsByDate(dateStr)
+
+            // 선택된 날짜도 업데이트 (기존 로직 유지)
             val calendar = Calendar.getInstance().apply {
                 set(Calendar.YEAR, year)
                 set(Calendar.MONTH, month)
@@ -194,18 +216,13 @@ class NoiseLogFragment : Fragment() {
                 return@setOnClickListener
             }
 
-            // TODO: [백엔드 연동] Repository를 통해 서버에 리포트 생성 요청
-            // TODO: [백엔드 연동] POST /api/reports { noiseLogIds: ["id1", "id2", ...] }
-            // TODO: [백엔드 연동] 요청 예시: viewModel.createReport(selectedLogs.map { it.id })
-            // TODO: [백엔드 연동] 성공 시 리포트 ID와 PDF 다운로드 URL 응답 받음
-            // TODO: [백엔드 연동] 실패 시 에러 메시지와 재시도 옵션 제공
+            // 리포트 생성 API 미구현 - 임시로 로컬 상태만 변경
             selectedLogs.forEach { log ->
                 viewModel.toggleReportStatus(log)
             }
 
             adapter.clearSelection()
             Toast.makeText(requireContext(), "${selectedLogs.size}개의 리포트가 생성되었습니다", Toast.LENGTH_SHORT).show()
-            // TODO: [백엔드 연동] 리포트 생성 완료 후 리포트 목록 화면으로 이동 옵션 제공
         }
     }
 
@@ -224,13 +241,61 @@ class NoiseLogFragment : Fragment() {
             }
         }
 
-        // TODO: [백엔드 연동] 에러 상태 관찰 추가
-        // TODO: [백엔드 연동] viewModel.errorState.collect { error -> showError(error) }
-        // TODO: [백엔드 연동] 로딩 상태 관찰 추가
-        // TODO: [백엔드 연동] viewModel.isLoading.collect { isLoading -> showLoading(isLoading) }
+        // 에러 상태 관찰
         viewLifecycleOwner.lifecycleScope.launch {
-            viewModel.noiseLogs.collect { logs ->
-                updateStats(logs)
+            viewModel.errorState.collect { error ->
+                error?.let {
+                    Toast.makeText(requireContext(), it, Toast.LENGTH_SHORT).show()
+                    viewModel.clearError()
+                }
+            }
+        }
+
+        // 로딩 상태 관찰
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.isLoading.collect { isLoading ->
+                // TODO: 프로그레스바 표시/숨김 처리
+                // binding.progressBar.visibility = if (isLoading) View.VISIBLE else View.GONE
+            }
+        }
+
+        // 캘린더 데이터 관찰 - hasNoiseLog가 true인 날짜를 하이라이트
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.calendarData.collect { calendarMap ->
+                // TODO: CalendarView에 데이터 반영
+                // calendarMap의 각 날짜에 대해 hasNoiseLog가 true이면 파란색 표시
+                // 예: calendarView.markDates(calendarMap.filter { it.value }.keys)
+
+                // 디버그용 로그 (실제로는 CalendarView 커스터마이징 필요)
+                val datesWithLog = calendarMap.filter { it.value }.keys
+                if (datesWithLog.isNotEmpty()) {
+                    // 소음 일기가 있는 날짜 개수 표시
+                    android.util.Log.d("NoiseLogFragment", "소음 일기가 있는 날짜: ${datesWithLog.size}개")
+                }
+            }
+        }
+
+        // 총 소음 기록 수 관찰 (API)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.totalCount.collect { count ->
+                binding.tvTotalCount.text = "${count}건"
+                android.util.Log.d("NoiseLogFragment", "총 소음 기록 수: ${count}건")
+            }
+        }
+
+        // 이번 달 소음 기록 수 관찰 (API)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.monthlyCount.collect { count ->
+                binding.tvMonthCount.text = "${count}건"
+                android.util.Log.d("NoiseLogFragment", "이번 달 소음 기록 수: ${count}건")
+            }
+        }
+
+        // 평균 dB 관찰 (API)
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.averageDb.collect { avgDb ->
+                binding.tvAvgDb.text = String.format("%.1f", avgDb)
+                android.util.Log.d("NoiseLogFragment", "평균 소음 레벨: ${String.format("%.2f", avgDb)} dB")
             }
         }
     }
@@ -248,35 +313,16 @@ class NoiseLogFragment : Fragment() {
         }
     }
 
-    /**
-     * 통계 정보 업데이트
-     * - 총 기록 수
-     * - 이번 달 기록 수
-     * - 평균 데시벨
-     */
-    private fun updateStats(logs: List<com.kau.ttokttok.domain.model.NoiseLog>) {
-        binding.tvTotalCount.text = "${logs.size}건"
-
-        val thisMonth = Calendar.getInstance().get(Calendar.MONTH)
-        val monthCount = logs.count { log ->
-            val cal = Calendar.getInstance().apply { time = log.measuredAt }
-            cal.get(Calendar.MONTH) == thisMonth
-        }
-        binding.tvMonthCount.text = "${monthCount}건"
-
-        val avgDb = if (logs.isNotEmpty()) {
-            logs.map { it.avgDecibel }.average().toInt()
-        } else {
-            0
-        }
-        binding.tvAvgDb.text = "$avgDb"
-    }
-
     override fun onResume() {
         super.onResume()
         // 다른 화면에서 돌아올 때 데이터 새로고침 (일기 추가/수정 후)
-        viewModel.loadAllLogs()
         viewModel.selectDate(viewModel.selectedDate.value)
+
+        // API 통계 데이터도 새로고침
+        val userId = 3L // TODO: 실제 userId로 교체
+        viewModel.loadTotalCount(userId)
+        viewModel.loadMonthlyCount(userId)
+        viewModel.loadAverageDb(userId)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogViewModel.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogViewModel.kt
@@ -9,24 +9,22 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import java.util.Calendar
 import java.util.Date
 import javax.inject.Inject
 
 /**
  * 소음 일기 기능 ViewModel
- * - 전체 일기 목록 관리
- * - 날짜별 일기 필터링
- * - 일기 CRUD 작업 (생성, 조회, 수정, 삭제)
+ * - 날짜별 소음 기록 조회 (API)
+ * - 월별 캘린더 데이터 조회 (API)
+ * - 소음 통계 조회: 총 개수, 월별 개수, 평균 dB (API)
+ * - 일기 CRUD 작업 (생성, 수정, 삭제)
  * - 리포트 생성 상태 관리
  */
 @HiltViewModel
 class NoiseLogViewModel @Inject constructor(
     private val repository: NoiseLogRepository // Hilt가 자동 주입
 ) : ViewModel() {
-
-    // 전체 소음 일기 목록
-    private val _noiseLogs = MutableStateFlow<List<NoiseLog>>(emptyList())
-    val noiseLogs: StateFlow<List<NoiseLog>> = _noiseLogs.asStateFlow()
 
     // 선택된 날짜
     private val _selectedDate = MutableStateFlow(Date())
@@ -36,103 +34,251 @@ class NoiseLogViewModel @Inject constructor(
     private val _selectedLogs = MutableStateFlow<List<NoiseLog>>(emptyList())
     val selectedLogs: StateFlow<List<NoiseLog>> = _selectedLogs.asStateFlow()
 
-    init {
-        loadAllLogs() // ViewModel 생성 시 전체 일기 로드
-    }
+    // 캘린더 데이터 (날짜 -> 소음 일기 존재 여부)
+    private val _calendarData = MutableStateFlow<Map<String, Boolean>>(emptyMap())
+    val calendarData: StateFlow<Map<String, Boolean>> = _calendarData.asStateFlow()
 
-    // TODO: [백엔드 연동] 로딩/에러 상태 관리를 위한 StateFlow 추가
-    // private val _isLoading = MutableStateFlow(false)
-    // val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
-    // private val _errorState = MutableStateFlow<String?>(null)
-    // val errorState: StateFlow<String?> = _errorState.asStateFlow()
+    // 로딩 상태
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
 
-    // 모든 일기 로드 - Repository에서 서버 또는 로컬 DB 데이터 가져옴
-    fun loadAllLogs() {
-        viewModelScope.launch {
-            // TODO: [백엔드 연동] _isLoading.value = true
-            repository.getAllNoiseLogs().onSuccess { logs ->
-                _noiseLogs.value = logs
-                // TODO: [백엔드 연동] _errorState.value = null
-            }.onFailure { error ->
-                // TODO: [백엔드 연동] _errorState.value = error.message
-                // TODO: [백엔드 연동] 네트워크 오류 시 로컬 캐시 데이터 사용 고려
-            }
-            // TODO: [백엔드 연동] _isLoading.value = false
-        }
-    }
+    // 에러 상태
+    private val _errorState = MutableStateFlow<String?>(null)
+    val errorState: StateFlow<String?> = _errorState.asStateFlow()
 
-    // 날짜 선택 및 해당 날짜의 일기 로드 - Repository를 통해 필터링된 데이터 가져옴
+    // 총 소음 기록 수
+    private val _totalCount = MutableStateFlow(0)
+    val totalCount: StateFlow<Int> = _totalCount.asStateFlow()
+
+    // 이번 달 소음 기록 수
+    private val _monthlyCount = MutableStateFlow(0)
+    val monthlyCount: StateFlow<Int> = _monthlyCount.asStateFlow()
+
+    // 전체 소음 기록 평균 dB
+    private val _averageDb = MutableStateFlow(0.0)
+    val averageDb: StateFlow<Double> = _averageDb.asStateFlow()
+
+    // 날짜 선택 및 해당 날짜의 일기 로드 - API를 통해 서버에서 데이터 가져옴
     fun selectDate(date: Date) {
         _selectedDate.value = date
-        viewModelScope.launch {
-            // TODO: [백엔드 연동] 서버에 날짜별 조회 API 호출 (GET /api/noise-logs?date=yyyy-MM-dd)
-            // TODO: [백엔드 연동] 또는 로컬에서 필터링 (현재 구현 방식)
-            repository.getNoiseLogsByDate(date).onSuccess { logs ->
-                _selectedLogs.value = logs
-            }.onFailure { error ->
-                // TODO: [백엔드 연동] _errorState.value = "날짜별 로그 조회 실패: ${error.message}"
-            }
-        }
+        // Date를 yyyy-MM-dd 형식으로 변환하여 API 호출
+        val dateString = formatDate(date)
+        loadNoiseRecordsByDate(dateString)
     }
 
     // 일기 삭제 - Repository를 통해 서버와 로컬 DB에서 삭제
     fun deleteLog(id: String) {
         viewModelScope.launch {
-            // TODO: [백엔드 연동] 낙관적 업데이트: UI에서 먼저 삭제 표시 후 서버 요청
+            _isLoading.value = true
             repository.deleteNoiseLog(id).onSuccess {
-                loadAllLogs()
+                _errorState.value = null
+                // 삭제 후 현재 날짜의 데이터만 새로고침
                 selectDate(_selectedDate.value)
             }.onFailure { error ->
-                // TODO: [백엔드 연동] 삭제 실패 시 롤백 및 사용자에게 알림
-                // TODO: [백엔드 연동] _errorState.value = "삭제 실패: ${error.message}"
+                _errorState.value = "삭제 실패: ${error.message}"
             }
+            _isLoading.value = false
         }
     }
 
     // 리포트 상태 토글 - 실제로는 별도의 리포트 생성 API 호출 필요
     fun toggleReportStatus(log: NoiseLog) {
         viewModelScope.launch {
-            // TODO: [백엔드 연동] 리포트 생성은 별도 API 사용 (POST /api/reports)
-            // TODO: [백엔드 연동] 요청: { noiseLogIds: [log.id], reportType: "monthly" }
-            // TODO: [백엔드 연동] 응답: { reportId, pdfUrl, createdAt }
+            _isLoading.value = true
             val updated = log.copy(hasReport = !log.hasReport)
             repository.updateNoiseLog(updated).onSuccess {
-                loadAllLogs()
+                _errorState.value = null
+                // 리포트 상태 변경 후 현재 날짜의 데이터만 새로고침
                 selectDate(_selectedDate.value)
             }.onFailure { error ->
-                // TODO: [백엔드 연동] _errorState.value = "리포트 생성 실패: ${error.message}"
+                _errorState.value = "리포트 생성 실패: ${error.message}"
             }
+            _isLoading.value = false
         }
     }
 
     // 새로운 소음 일기 저장 - Repository를 통해 서버에 저장
     fun saveLog(log: NoiseLog) {
         viewModelScope.launch {
-            // TODO: [백엔드 연동] POST /api/noise-logs
-            // TODO: [백엔드 연동] 요청 본문: NoiseLog 객체 (id는 null)
-            // TODO: [백엔드 연동] 응답: 서버에서 생성한 ID 포함된 NoiseLog 객체
+            _isLoading.value = true
             repository.saveNoiseLog(log).onSuccess {
-                loadAllLogs()
+                _errorState.value = null
+                // 저장 후 해당 날짜의 데이터만 새로고침
                 selectDate(_selectedDate.value)
             }.onFailure { error ->
-                // TODO: [백엔드 연동] 네트워크 오류 시 로컬에 임시 저장 (offline-first 전략)
-                // TODO: [백엔드 연동] _errorState.value = "저장 실패: ${error.message}"
+                _errorState.value = "저장 실패: ${error.message}"
             }
+            _isLoading.value = false
         }
     }
 
-    // 소음 일기 수정 - Repository를 통해 서버의 데이터 업데이트
-    fun updateLog(log: NoiseLog) {
+    /**
+     * 캘린더 월별 데이터 로드 - 백엔드 API 호출
+     * @param userId 회원 고유 ID
+     * @param year 조회할 연도
+     * @param month 조회할 월 (1~12)
+     */
+    fun loadCalendarData(userId: Long, year: Int, month: Int) {
         viewModelScope.launch {
-            // TODO: [백엔드 연동] PUT /api/noise-logs/{id}
-            // TODO: [백엔드 연동] 수정 권한 확인 (본인이 작성한 일기인지 서버에서 검증)
-            repository.updateNoiseLog(log).onSuccess {
-                loadAllLogs()
-                selectDate(_selectedDate.value)
-            }.onFailure { error ->
-                // TODO: [백엔드 연동] 권한 없음(403) 또는 수정 실패 에러 처리
-                // TODO: [백엔드 연동] _errorState.value = "수정 실패: ${error.message}"
-            }
+            _isLoading.value = true
+            _errorState.value = null
+
+            repository.getCalendarData(userId, year, month)
+                .onSuccess { calendarMap ->
+                    _calendarData.value = calendarMap
+                    _errorState.value = null
+                }
+                .onFailure { error ->
+                    _errorState.value = "캘린더 데이터 로드 실패: ${error.message}"
+                    _calendarData.value = emptyMap()
+                }
+
+            _isLoading.value = false
+        }
+    }
+
+    /**
+     * 현재 월의 캘린더 데이터 로드
+     */
+    fun loadCurrentMonthCalendar(userId: Long) {
+        val calendar = Calendar.getInstance()
+        val year = calendar.get(Calendar.YEAR)
+        val month = calendar.get(Calendar.MONTH) + 1 // Calendar.MONTH는 0부터 시작
+        loadCalendarData(userId, year, month)
+    }
+
+    /**
+     * 에러 상태 초기화
+     */
+    fun clearError() {
+        _errorState.value = null
+    }
+
+    /**
+     * 날짜별 소음 기록 상세 조회 - 백엔드 API 호출
+     * @param date 조회할 날짜 (yyyy-MM-dd 형식)
+     */
+    fun loadNoiseRecordsByDate(date: String) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorState.value = null
+
+            repository.getNoiseRecordsByDate(date)
+                .onSuccess { logs ->
+                    _selectedLogs.value = logs
+                    _errorState.value = null
+                }
+                .onFailure { error ->
+                    _errorState.value = "소음 기록 조회 실패: ${error.message}"
+                    _selectedLogs.value = emptyList()
+                }
+
+            _isLoading.value = false
+        }
+    }
+
+    /**
+     * Date 객체를 yyyy-MM-dd 형식의 문자열로 변환
+     */
+    private fun formatDate(date: Date): String {
+        val format = java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.getDefault())
+        return format.format(date)
+    }
+
+    /**
+     * 총 소음 기록 수 조회 - 백엔드 API 호출
+     * @param userId 조회할 사용자의 ID
+     */
+    fun loadTotalCount(userId: Long) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorState.value = null
+
+            repository.getTotalCount(userId)
+                .onSuccess { count ->
+                    _totalCount.value = count
+                    _errorState.value = null
+                }
+                .onFailure { error ->
+                    _errorState.value = "총 기록 수 조회 실패: ${error.message}"
+                    _totalCount.value = 0
+                }
+
+            _isLoading.value = false
+        }
+    }
+
+    /**
+     * 이번 달 소음 기록 수 조회 - 백엔드 API 호출
+     * @param userId 조회할 사용자의 ID
+     */
+    fun loadMonthlyCount(userId: Long) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorState.value = null
+
+            val calendar = Calendar.getInstance()
+            val year = calendar.get(Calendar.YEAR)
+            val month = calendar.get(Calendar.MONTH) + 1 // Calendar.MONTH는 0부터 시작
+
+            repository.getMonthlyCount(userId, year, month)
+                .onSuccess { count ->
+                    _monthlyCount.value = count
+                    _errorState.value = null
+                }
+                .onFailure { error ->
+                    _errorState.value = "이번 달 기록 수 조회 실패: ${error.message}"
+                    _monthlyCount.value = 0
+                }
+
+            _isLoading.value = false
+        }
+    }
+
+    /**
+     * 전체 소음 기록 평균 dB 조회 - 백엔드 API 호출
+     * @param userId 조회할 사용자의 ID
+     */
+    fun loadAverageDb(userId: Long) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorState.value = null
+
+            repository.getAverageDb(userId)
+                .onSuccess { avgDb ->
+                    _averageDb.value = avgDb
+                    _errorState.value = null
+                }
+                .onFailure { error ->
+                    _errorState.value = "평균 dB 조회 실패: ${error.message}"
+                    _averageDb.value = 0.0
+                }
+
+            _isLoading.value = false
+        }
+    }
+
+    /**
+     * 소음 일기 수정 (API 연동) - 백엔드 API 호출
+     * @param recordId 수정할 소음 기록의 고유 ID
+     * @param log 수정할 소음 일기 데이터
+     */
+    fun updateLogApi(recordId: Long, log: NoiseLog) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorState.value = null
+
+            repository.updateNoiseRecordApi(recordId, log)
+                .onSuccess { updatedLog ->
+                    _errorState.value = null
+                    // 수정 성공 시 현재 날짜의 데이터만 새로고침
+                    selectDate(_selectedDate.value)
+                }
+                .onFailure { error ->
+                    _errorState.value = "소음 일기 수정 실패: ${error.message}"
+                }
+
+            _isLoading.value = false
         }
     }
 }

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogViewModel.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogViewModel.kt
@@ -259,6 +259,51 @@ class NoiseLogViewModel @Inject constructor(
     }
 
     /**
+     * 소음 일기 등록 (API 연동) - 백엔드 API 호출
+     * @param occuredAt 소음 발생 시간 (ISO 8601 형식)
+     * @param duration 측정 소요 시간(녹음 duration)
+     * @param dbHigh 최대 데시벨
+     * @param dbAvg 평균 데시벨
+     * @param category 소음 카테고리 (FOOTSTEPS, HAMMERING, FURNITURE, MUSIC, UNKNOWN)
+     * @param grade 소음 등급 (QUIET, NORMAL, LOUD)
+     * @param description 소음일기 내용
+     */
+    fun createNoiseRecordApi(
+        occuredAt: String,
+        duration: Int,
+        dbHigh: Double,
+        dbAvg: Double,
+        category: String,
+        grade: String,
+        description: String?
+    ) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorState.value = null
+
+            repository.createNoiseRecordApi(
+                occuredAt = occuredAt,
+                duration = duration,
+                dbHigh = dbHigh,
+                dbAvg = dbAvg,
+                category = category,
+                grade = grade,
+                description = description
+            )
+                .onSuccess { createdLog ->
+                    _errorState.value = null
+                    // 등록 성공 시 현재 날짜의 데이터만 새로고침
+                    selectDate(_selectedDate.value)
+                }
+                .onFailure { error ->
+                    _errorState.value = "소음 일기 등록 실패: ${error.message}"
+                }
+
+            _isLoading.value = false
+        }
+    }
+
+    /**
      * 소음 일기 수정 (API 연동) - 백엔드 API 호출
      * @param recordId 수정할 소음 기록의 고유 ID
      * @param log 수정할 소음 일기 데이터
@@ -276,6 +321,29 @@ class NoiseLogViewModel @Inject constructor(
                 }
                 .onFailure { error ->
                     _errorState.value = "소음 일기 수정 실패: ${error.message}"
+                }
+
+            _isLoading.value = false
+        }
+    }
+
+    /**
+     * 소음 일기 삭제 (API 연동 - Hard Delete) - 백엔드 API 호출
+     * @param recordId 삭제할 소음 기록의 고유 ID
+     */
+    fun deleteNoiseRecordApi(recordId: Long) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _errorState.value = null
+
+            repository.deleteNoiseRecordApi(recordId)
+                .onSuccess { deletedRecordId ->
+                    _errorState.value = null
+                    // 삭제 성공 시 현재 날짜의 데이터만 새로고침
+                    selectDate(_selectedDate.value)
+                }
+                .onFailure { error ->
+                    _errorState.value = "소음 일기 삭제 실패: ${error.message}"
                 }
 
             _isLoading.value = false

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseMeasurementFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseMeasurementFragment.kt
@@ -252,23 +252,14 @@ class NoiseMeasurementFragment : Fragment() {
     private fun stopMeasurementAndNavigate() { // 측정 종료 후 결과 화면으로 이동
         stopMeasurement()
 
-        // TODO: [백엔드 연동] 측정 원시 데이터를 서버에 임시 저장 (선택 사항)
-        // TODO: [백엔드 연동] POST /api/noise-measurements
-        // TODO: [백엔드 연동] 요청 본문: { maxDb, avgDb, duration, dbList, measuredAt }
-        // TODO: [백엔드 연동] 오디오 녹음 기능 추가 시 음성 파일 업로드 (Multipart)
-        // TODO: [백엔드 연동] 측정 ID를 받아서 NoiseLog 저장 시 참조
-
+        // 측정 데이터 저장 API는 미구현 - 소음일기 저장 시에만 서버 전송
         val bundle = Bundle().apply {
             putDouble("max_db", maxDb)
             putDouble("avg_db", avgDb)
             putLong("duration", (System.currentTimeMillis() - startTime) / 1000)
             putLong("measured_at", startTime)
-            // TODO: [백엔드 연동] 서버에서 받은 측정 ID 추가
-            // putString("measurement_id", measurementId)
         }
 
-        // TODO: [백엔드 연동] Navigation 시 측정 데이터를 ViewModel로 관리하는 것도 고려
-        // TODO: [백엔드 연동] viewModel.setMeasurementData(maxDb, avgDb, duration, measuredAt)
         findNavController().navigateTo(Destination.NOISE_LOG_FORM, bundle)
         Toast.makeText(requireContext(), "측정이 완료되었습니다", Toast.LENGTH_SHORT).show()
     }


### PR DESCRIPTION
소음일기 캘린더 기능 백엔드 연동입니다. API 명세서 완료 된 것만 했습니다.

NetworkModule에 일부 수정사항 있습니다. 주소도 실제 주소로 바꿔놔서 충돌 우려가 있습니다.

그 밖에도 NoiseApiService / CalendarResponse.kt 가 추가 되었습니다.