### PR TITLE
setting 2

### DIFF
--- a/app/src/main/java/com/kau/ttokttok/_core/network/di/RepositoryModule.kt
+++ b/app/src/main/java/com/kau/ttokttok/_core/network/di/RepositoryModule.kt
@@ -7,6 +7,7 @@ import com.kau.ttokttok.data.local.repository.NoiseLogRepositoryImpl
 import com.kau.ttokttok.data.local.repository.NotificationRepositoryImpl
 import com.kau.ttokttok.data.local.repository.PreConsiderationRepositoryImpl
 import com.kau.ttokttok.data.local.repository.ReportRepositoryImpl
+import com.kau.ttokttok.data.local.repository.SettingRepositoryImpl
 import com.kau.ttokttok.domain.repository.AuthRepository
 import com.kau.ttokttok.domain.repository.CommunityRepository
 import com.kau.ttokttok.domain.repository.NoiseVoteRepository
@@ -14,6 +15,7 @@ import com.kau.ttokttok.domain.repository.NoiseLogRepository
 import com.kau.ttokttok.domain.repository.NotificationRepository
 import com.kau.ttokttok.domain.repository.PreConsiderationRepository
 import com.kau.ttokttok.domain.repository.ReportRepository
+import com.kau.ttokttok.domain.repository.SettingRepository
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -64,4 +66,10 @@ abstract class RepositoryModule {
     abstract fun bindReportRepository(
         impl: ReportRepositoryImpl
     ): ReportRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsSettingRepository(
+        impl: SettingRepositoryImpl
+    ): SettingRepository
 }

--- a/app/src/main/java/com/kau/ttokttok/data/local/repository/SettingRepositoryImpl.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/local/repository/SettingRepositoryImpl.kt
@@ -1,0 +1,41 @@
+package com.kau.ttokttok.data.local.repository
+
+import com.kau.ttokttok._core.network.result.NetworkResult
+import com.kau.ttokttok.domain.repository.SettingRepository
+import javax.inject.Inject
+
+class SettingRepositoryImpl @Inject constructor() : SettingRepository {
+    override suspend fun getNotice(): NetworkResult<String> {
+        val Notice = """
+            안녕하세요, 똑똑입니다.
+            
+            서비스 안정화를 위해 아래와 같이 시스템 점검을 진행할 예정입니다.
+            새벽 시간에는 서비스 이용이 원활하지 않을 수 있으니 양해 부탁드립니다.
+            
+            - 점검 일시: 2025년 12월 22일 (월) 02:00 ~ 04:00
+            - 점검 내용: 서버 안정화 및 데이터베이스 최적화
+            
+            더 좋은 서비스로 보답하겠습니다.
+            감사합니다.
+            """.trimIndent()
+            return NetworkResult.Success(Notice)
+    }
+
+    override suspend fun getTerms(): NetworkResult<String> {
+        val Terms = """
+            제1조 (목적)
+            이 약관은 똑똑(이하 "회사")이 제공하는 똑똑 및 똑똑 관련 제반 서비스의 이용과 관련하여 회사와 회원과의 권리, 의무 및 책임사항, 기타 필요한 사항을 규정함을 목적으로 합니다.
+            
+             ... (이하 생략) ...
+             """.trimIndent()
+             return NetworkResult.Success(Terms)
+    }
+    override suspend fun getPrivacyPolicy(): NetworkResult<String> {
+        val Policy = """
+            '똑똑'은(는) 「개인정보 보호법」 제30조에 따라 정보주체의 개인정보를 보호하고 이와 관련한 고충을 신속하고 원활하게 처리할 수 있도록 하기 위하여 다음과 같이 개인정보 처리방침을 수립·공개합니다.            
+            
+             ... (이하 생략) ...
+             """.trimIndent()
+             return NetworkResult.Success(Policy)
+    }
+}

--- a/app/src/main/java/com/kau/ttokttok/domain/repository/SettingRepository.kt
+++ b/app/src/main/java/com/kau/ttokttok/domain/repository/SettingRepository.kt
@@ -1,0 +1,9 @@
+package com.kau.ttokttok.domain.repository
+
+import com.kau.ttokttok._core.network.result.NetworkResult
+
+interface SettingRepository {
+    suspend fun getNotice(): NetworkResult<String>
+    suspend fun getTerms(): NetworkResult<String>
+    suspend fun getPrivacyPolicy(): NetworkResult<String>
+}

--- a/app/src/main/java/com/kau/ttokttok/domain/usecase/AuthUseCase.kt
+++ b/app/src/main/java/com/kau/ttokttok/domain/usecase/AuthUseCase.kt
@@ -9,6 +9,7 @@ import com.kau.ttokttok.data.remote.dto.auth.req.RegisterReq
 import com.kau.ttokttok.data.remote.dto.auth.res.LoginRes
 import com.kau.ttokttok.data.remote.dto.auth.res.RegisterRes
 import com.kau.ttokttok.domain.repository.AuthRepository
+import okhttp3.Address
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -62,5 +63,16 @@ class AuthUseCase @Inject constructor(
         }
 
         return result
+    }
+    suspend fun logout() {
+        tokenProvider.clear()
+        userProvider.clear()
+    }
+
+    suspend fun changePassword(password: String): NetworkResult<String> {
+        return NetworkResult.Success("비밀번호 변경 성공")
+    }
+    suspend fun changeAddress(address: String): NetworkResult<String> {
+        return NetworkResult.Success("거주지 변경 성공")
     }
 }

--- a/app/src/main/java/com/kau/ttokttok/domain/usecase/SettingUseCase.kt
+++ b/app/src/main/java/com/kau/ttokttok/domain/usecase/SettingUseCase.kt
@@ -1,0 +1,21 @@
+package com.kau.ttokttok.domain.usecase
+
+import com.kau.ttokttok._core.network.result.NetworkResult
+import com.kau.ttokttok.domain.repository.SettingRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SettingUseCase @Inject constructor(
+    private val repository: SettingRepository
+) {
+    suspend fun getNotice(): NetworkResult<String> {
+        return repository.getNotice()
+    }
+    suspend fun getTerms(): NetworkResult<String> {
+        return repository.getTerms()
+    }
+    suspend fun getPrivacyPolicy(): NetworkResult<String> {
+        return repository.getPrivacyPolicy()
+    }
+}

--- a/app/src/main/java/com/kau/ttokttok/ui/component/common/TtokTtokInputDialog.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/component/common/TtokTtokInputDialog.kt
@@ -1,0 +1,73 @@
+package com.kau.ttokttok.ui.component.common
+
+import android.R
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+
+
+@Composable
+fun TtokTtokInputDialog(
+    title: String,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+    confirmText: String = "확인",
+    dismissText: String = "취소",
+    content: @Composable ColumnScope.() -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .clip(RoundedCornerShape(12.dp))
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(24.dp)
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+
+            content()
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Spacer(modifier = Modifier.weight(1f))
+                // 취소 버튼
+                TextButton(onClick = onDismiss) {
+                    Text(
+                        text = dismissText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                // 확인 버튼
+                TextButton(onClick = onConfirm) {
+                    Text(
+                        text = confirmText,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/SettingRoute.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/SettingRoute.kt
@@ -1,14 +1,27 @@
 package com.kau.ttokttok.ui.compose.setting
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.kau.ttokttok.ui.component.common.AppDialog
+import com.kau.ttokttok.ui.component.common.TtokTtokInputDialog
 import com.kau.ttokttok.ui.navigation.Destination
 
 @Composable
@@ -22,6 +35,14 @@ fun SettingRoute(
     // viewModel의 uiState를 관찰 중
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     // 다이얼로그 표시 상태
+    var showChangeAddressConfirmDialog by remember {  mutableStateOf(false) }
+    var showAddressChangeSuccessDialog by remember { mutableStateOf(false) }
+    var showAddressChangeFailureDialog by remember { mutableStateOf(false) }
+    var addressChangeFailureMessage by remember { mutableStateOf("") }
+    var showChangePasswordConfirmDialog by remember {  mutableStateOf(false) }
+    var showPasswordChangeSuccessDialog by remember { mutableStateOf(false) }
+    var showPasswordChangeFailureDialog by remember { mutableStateOf(false) }
+    var passwordChangeFailureMessage by remember { mutableStateOf("") }     // 실패 메시지 저장할 변수
     var showNoticeDialog by remember { mutableStateOf(false) }
     var showTermsDialog by remember { mutableStateOf(false) }
     var showPrivacyDialog by remember { mutableStateOf(false) }
@@ -40,14 +61,25 @@ fun SettingRoute(
                 SettingEvent.NavigateToEditProfile -> {
                     onNavigate(Destination.EDIT_PROFILE)
                 }
-                SettingEvent.NavigateToChangeNickname -> {
-                    onNavigate(Destination.CHANGE_NICKNAME)
+                SettingEvent.ShowChangeAddressConfirmDialog -> {
+                    showChangeAddressConfirmDialog = true
                 }
-                SettingEvent.NavigateToChangeAddress -> {
-                    onNavigate(Destination.CHANGE_ADDRESS)
+                SettingEvent.ShowAddressChangeSuccessDialog -> {
+                    showAddressChangeSuccessDialog = true
                 }
-                SettingEvent.NavigateToChangePassword -> {
-                    onNavigate(Destination.CHANGE_PASSWORD)
+                is SettingEvent.ShowAddressChangeFailureDialog -> {
+                    addressChangeFailureMessage = event.message
+                    showAddressChangeFailureDialog = true
+                }
+                SettingEvent.ShowChangePasswordConfirmDialog -> {
+                    showChangePasswordConfirmDialog = true
+                }
+                SettingEvent.ShowPasswordChangeSuccessDialog -> {
+                    showPasswordChangeSuccessDialog = true
+                }
+                is SettingEvent.ShowPasswordChangeFailureDialog -> {
+                    passwordChangeFailureMessage = event.message
+                    showPasswordChangeFailureDialog = true
                 }
                 SettingEvent.ShowNoticeDialog -> {
                     showNoticeDialog = true
@@ -73,12 +105,83 @@ fun SettingRoute(
         uiState = uiState,
         onEvent = viewModel::onUiAction,
         onBack = onBack,
+        onConfirmLogout = viewModel::performLogout
     )
+    // 거주지변경 다이얼로그
+    if (showChangeAddressConfirmDialog) {
+        TtokTtokInputDialog(
+            title = "거주지 변경",
+            onDismiss = { showChangeAddressConfirmDialog = false },
+            onConfirm = { viewModel.onUiAction(SettingUiAction.OnChangeAddressConfirmClicked) },
+            confirmText = "변경"
+        ) {
+            Column {
+                OutlinedTextField(
+                    value = uiState.newAddressInput,
+                    onValueChange = {
+                        viewModel.onUiAction(
+                            SettingUiAction.OnNewAddressInputChanged(
+                                it
+                            )
+                        )
+                    },
+                    label = { Text("새 거주지") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                uiState.addressChangeError?.let { error ->
+                    Text(
+                        text = error,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+            }
+        }
+    }
+    // 비밀번호 변경 다이얼로그
+    if (showChangePasswordConfirmDialog) {
+        TtokTtokInputDialog(
+            title = "비밀번호 변경",
+            onDismiss = { showChangePasswordConfirmDialog = false },
+            dismissText = "취소",
+            onConfirm = { viewModel.onUiAction(SettingUiAction.OnChangePasswordConfirmClicked) },
+            confirmText = "변경"
+        ) {
+            Column {
+                OutlinedTextField(
+                    value = uiState.newPasswordInput,
+                    onValueChange = { viewModel.onUiAction(SettingUiAction.OnNewPasswordInputChanged(it)) },
+                    label = { Text("새 비밀번호") },
+                    visualTransformation = PasswordVisualTransformation(),
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+
+                OutlinedTextField(
+                    value = uiState.newPasswordConfirmInput,
+                    onValueChange = { viewModel.onUiAction(SettingUiAction.OnNewPasswordConfirmInputChanged(it)) },
+                    label = { Text("새 비밀번호 확인") },
+                    visualTransformation = PasswordVisualTransformation(),
+                    modifier = Modifier.fillMaxWidth()
+                )
+                uiState.passwordChangeError?.let { error ->
+                    Text(
+                        text = error,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+            }
+        }
+    }
     // 공지사항 다이얼로그
     if (showNoticeDialog) {
         AppDialog(
             title = "앱 공지사항",
-            message = "공지사항 내용",
+            message = uiState.noticeContent,
             onDismiss = { showNoticeDialog = false }
         )
     }
@@ -86,7 +189,7 @@ fun SettingRoute(
     if (showTermsDialog) {
         AppDialog(
             title = "서비스 이용약관",
-            message = "이용 약관 내용",
+            message = uiState.termsContent,
             onDismiss = { showTermsDialog = false }
         )
     }
@@ -94,7 +197,7 @@ fun SettingRoute(
     if (showPrivacyDialog) {
         AppDialog(
             title = "개인정보 처리방침",
-            message = "개인정보 처리방침 내용",
+            message = uiState.privacyPolicyContent,
             onDismiss = { showPrivacyDialog = false }
         )
     }
@@ -106,6 +209,7 @@ fun SettingRoute(
             onDismiss = { showLogoutDialog = false },
             dismissText = "취소",
             onConfirm = {
+                viewModel.performLogout()
                 showLogoutDialog = false
                 onResetToLogin()
             },
@@ -120,10 +224,53 @@ fun SettingRoute(
             onDismiss = { showDeleteAccountDialog = false },
             dismissText = "취소",
             onConfirm = {
+                viewModel.performLogout()
                 showDeleteAccountDialog = false
                 onResetToLogin()
             },
             confirmText = "탈퇴 완료"
+        )
+    }
+    // 거주지 변경 성공 다이얼로그
+    if (showAddressChangeSuccessDialog) {
+        AppDialog(
+            title = "거주지 변경",
+            message = "거주지가 성공적으로 변경되었습니다.",
+            onDismiss = { showAddressChangeSuccessDialog = false },
+            onConfirm = { showAddressChangeSuccessDialog = false },
+            confirmText = "확인"
+        )
+    }
+
+    // 거주지 변경 실패 다이얼로그
+    if (showAddressChangeFailureDialog) {
+        AppDialog(
+            title = "거주지 변경 실패",
+            message = addressChangeFailureMessage,
+            onDismiss = { showAddressChangeFailureDialog = false },
+            onConfirm = { showAddressChangeFailureDialog = false },
+            confirmText = "확인"
+        )
+    }
+
+    // 비밀번호 변경 성공 다이얼로그
+    if (showPasswordChangeSuccessDialog) {
+        AppDialog(
+            title = "비밀번호 변경",
+            message = "비밀번호가 성공적으로 변경되었습니다.",
+            onDismiss = { showPasswordChangeSuccessDialog = false },
+            onConfirm = { showPasswordChangeSuccessDialog = false },
+            confirmText = "확인"
+        )
+    }
+    // 비밀번호 변경 실패 다이얼로그
+    if (showPasswordChangeFailureDialog) {
+        AppDialog(
+            title = "비밀번호 변경 실패",
+            message = passwordChangeFailureMessage,
+            onDismiss = { showPasswordChangeFailureDialog = false },
+            onConfirm = { showPasswordChangeFailureDialog = false },
+            confirmText = "확인"
         )
     }
 }

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/SettingScreen.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/SettingScreen.kt
@@ -67,7 +67,8 @@ fun SettingScreen(
     modifier: Modifier = Modifier,
     uiState: SettingUiState = SettingUiState(),
     onEvent: (SettingUiAction) -> Unit = {},
-    onBack: () -> Unit = {}
+    onBack: () -> Unit = {},
+    onConfirmLogout: () -> Unit = {}
 ) {
     val scroll = rememberScrollState()
 
@@ -170,7 +171,6 @@ fun SettingScreen(
                     // TODO: viewModel 연결
                     SettingCard {
                         AccountManagementSection(
-                            onChangeNickname = {onEvent(SettingUiAction.OnChangeNicknameClicked)},
                             onChangeAddress = {onEvent(SettingUiAction.OnChangeAddressClicked)},
                             onChangePassword = {onEvent(SettingUiAction.OnChangePasswordClicked)},
                             onLogout = {onEvent(SettingUiAction.OnLogoutClicked)},
@@ -445,7 +445,6 @@ private fun SettingToggleRow(
 
 @Composable
 fun AccountManagementSection(
-    onChangeNickname: () -> Unit,
     onChangeAddress: () -> Unit,
     onChangePassword: () -> Unit,
     onLogout: () -> Unit,
@@ -475,11 +474,6 @@ fun AccountManagementSection(
 
         // Content
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            SettingRow(
-                icon = Icons.Filled.Edit,
-                title = "닉네임 변경",
-                onClick = onChangeNickname
-            )
             SettingRow(
                 icon = Icons.Filled.Home,
                 title = "거주지 변경",

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/SettingViewModel.kt
@@ -1,14 +1,19 @@
 package com.kau.ttokttok.ui.compose.setting
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.kau.ttokttok._core.network.auth.UserProvider
+import com.kau.ttokttok._core.network.result.NetworkResult
 import com.kau.ttokttok.domain.model.User
+import com.kau.ttokttok.domain.usecase.AuthUseCase
+import com.kau.ttokttok.domain.usecase.SettingUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 import kotlinx.serialization.internal.throwMissingFieldException
 import javax.inject.Inject
 
@@ -32,21 +37,34 @@ data class SettingUiState(
     val canNotifyPreConsideration: Boolean = true,
     val canNotifyCommunity: Boolean = true,
 
-    val user: User? = null
+    val user: User? = null,
+
+    val newAddressInput: String = "",
+    val addressChangeError: String? = null,
+
+    val newPasswordInput: String = "",
+    val newPasswordConfirmInput: String = "",
+    val passwordChangeError: String? = null,
+    val noticeContent: String = "",
+    val termsContent: String = "",
+    val privacyPolicyContent: String = ""
 )
 
 // TODO: EVENT 정의
 // Event에 맞게 UI를 다시 만들어라
 sealed interface SettingEvent {
     data object NavigateToEditProfile : SettingEvent            // 프로필 수정 화면으로 이동
-    data object NavigateToChangeNickname : SettingEvent         // 닉네임 변경 화면으로 이동
-    data object NavigateToChangeAddress : SettingEvent          // 거주지 변경 화면으로 이동
-    data object NavigateToChangePassword : SettingEvent         // 비밀번호 변경 화면으로 이동
-    data object ShowNoticeDialog : SettingEvent              // 공지사항 화면을호 이동
+    data object ShowChangeAddressConfirmDialog : SettingEvent                  // 거주지 변경 화면으로 이동
+    data object ShowChangePasswordConfirmDialog : SettingEvent                 // 비밀번호 변경 화면으로 이동
+    data object ShowNoticeDialog : SettingEvent                 // 공지사항 화면으로 이동
     data object ShowTermsDialog : SettingEvent                  // 서비스 이용약관 화면으로 이동
     data object ShowPrivacyDialog : SettingEvent                // 개인정보 처리방침 화면으로 이동
     data object ShowLogoutConfirmDialog : SettingEvent          // 로그아웃 다이얼로그
     data object ShowDeleteAccountConfirmDialog : SettingEvent   // 탈퇴 다이얼로그
+    data object ShowPasswordChangeSuccessDialog : SettingEvent  // 비밀번호 변경 성공 다이얼로그
+    data class ShowPasswordChangeFailureDialog(val message: String) : SettingEvent // 비밀번호 변경 실패 다이얼로그
+    data object ShowAddressChangeSuccessDialog : SettingEvent // 거주지 변경 성공 다이얼로그
+    data class ShowAddressChangeFailureDialog(val message: String) : SettingEvent // 거주지 변경 실패 다이얼로그
 }
 
 // TODO: UiAction 정의
@@ -54,9 +72,10 @@ sealed interface SettingEvent {
 sealed interface SettingUiAction {
     data object OnEditProfileClicked : SettingUiAction          // 가장 상단 수정 버튼 클릭
     //계정 관리
-    data object OnChangeNicknameClicked : SettingUiAction       // 닉네임 변경 클릭
     data object OnChangeAddressClicked : SettingUiAction        // 거주지 변경 클릭
+    data object OnChangeAddressConfirmClicked : SettingUiAction      // 다이얼로그에서 변경 아이콘 클릭 시 (주소 변경)
     data object OnChangePasswordClicked : SettingUiAction       // 비밀번호 변경 클릭
+    data object OnChangePasswordConfirmClicked : SettingUiAction        // 다이얼로그에서 변경 아이콘 클릭 시 (비밀번호 변경)
     data object OnLogoutClicked : SettingUiAction               // 로그아웃 클릭
     data object OnDeleteAccountClicked : SettingUiAction        // 회원 탈퇴 클릭
     // 앱 정보
@@ -68,13 +87,18 @@ sealed interface SettingUiAction {
     data class OnToggleNotifyNoiseVote(val checked: Boolean) : SettingUiAction          //소음 확인
     data class OnToggleNotifyPreConsideration(val checked: Boolean) : SettingUiAction   // 사전양해 알림
     data class OnToggleNotifyCommunity(val checked: Boolean) : SettingUiAction          // 공지사항 알림
+    data class OnNewAddressInputChanged(val address: String) : SettingUiAction
+    data class OnNewPasswordInputChanged(val password: String) : SettingUiAction
+    data class OnNewPasswordConfirmInputChanged(val passwordConfirm: String) : SettingUiAction
 }
 
 @HiltViewModel
 class SettingViewModel @Inject constructor(
 // BE연동시 repository 만들고 주입 후 사용
 // private val repository: SettingRepository,
-    private val userProvider: UserProvider
+    private val userProvider: UserProvider,
+    private val authUseCase: AuthUseCase,
+    private val settingUseCase: SettingUseCase
 ): ViewModel() {
 
     // 화면 상태를 보관하는 StateFlow
@@ -124,12 +148,16 @@ class SettingViewModel @Inject constructor(
             is SettingUiAction.OnToggleNotifyCommunity -> _uiState.value = _uiState.value.copy(canNotifyCommunity = action.checked)
 
             SettingUiAction.OnEditProfileClicked -> emit(SettingEvent.NavigateToEditProfile)
-            SettingUiAction.OnChangeNicknameClicked -> emit(SettingEvent.NavigateToChangeNickname)
-            SettingUiAction.OnChangeAddressClicked -> emit(SettingEvent.NavigateToChangeAddress)
-            SettingUiAction.OnChangePasswordClicked -> emit(SettingEvent.NavigateToChangePassword)
-            SettingUiAction.OnNoticeClicked -> emit(SettingEvent.ShowNoticeDialog)
-            SettingUiAction.OnTermsClicked -> emit(SettingEvent.ShowTermsDialog)
-            SettingUiAction.OnPrivacyClicked -> emit(SettingEvent.ShowPrivacyDialog)
+            SettingUiAction.OnChangeAddressClicked -> emit(SettingEvent.ShowChangeAddressConfirmDialog)
+            SettingUiAction.OnChangePasswordClicked -> emit(SettingEvent.ShowChangePasswordConfirmDialog)
+            is SettingUiAction.OnNewPasswordInputChanged -> _uiState.value = _uiState.value.copy(newPasswordInput = action.password)
+            is SettingUiAction.OnNewPasswordConfirmInputChanged -> _uiState.value = _uiState.value.copy(newPasswordConfirmInput = action.passwordConfirm)
+            is SettingUiAction.OnNewAddressInputChanged -> _uiState.value = _uiState.value.copy(newAddressInput = action.address)
+            SettingUiAction.OnChangeAddressConfirmClicked -> changeAddress()
+            SettingUiAction.OnChangePasswordConfirmClicked -> changePassword()
+            SettingUiAction.OnNoticeClicked -> loadNotice()
+            SettingUiAction.OnTermsClicked -> loadTerms()
+            SettingUiAction.OnPrivacyClicked -> loadPrivacyPolicy()
 
             SettingUiAction.OnLogoutClicked -> emit(SettingEvent.ShowLogoutConfirmDialog)
             SettingUiAction.OnDeleteAccountClicked -> emit(SettingEvent.ShowDeleteAccountConfirmDialog)
@@ -163,6 +191,110 @@ class SettingViewModel @Inject constructor(
             canNotifyCommunity = checked,
         )
     }
+
+    fun performLogout() {
+        viewModelScope.launch {
+            authUseCase.logout()
+        }
+    }
+
+    private fun changeAddress() {
+        viewModelScope.launch {
+            val newAddress = _uiState.value.newAddressInput
+
+            // 빈 값 검사
+            if (newAddress.isBlank()) {
+                _uiState.value = _uiState.value.copy(addressChangeError = "거주지를 입력해주세요.")
+                return@launch
+            }
+
+            _uiState.value = _uiState.value.copy(addressChangeError = null)
+            val result = authUseCase.changeAddress(newAddress)
+
+            when (result) {
+                is NetworkResult.Success -> {
+                    emit(SettingEvent.ShowAddressChangeSuccessDialog)
+                    _uiState.value = _uiState.value.copy(newAddressInput = "") // 성공 시 입력 필드 초기화
+                }
+                is NetworkResult.Error -> {
+                    emit(SettingEvent.ShowAddressChangeFailureDialog("거주지 변경 실패: ${result.message}"))
+                }
+            }
+        }
+    }
+
+    private fun changePassword() {
+        viewModelScope.launch {
+            val newPasswordConfirm = _uiState.value.newPasswordConfirmInput
+            val newPassword = _uiState.value.newPasswordInput
+
+            // 빈 값 검사
+            if (newPassword.isBlank() || newPasswordConfirm.isBlank()) {
+                _uiState.value = _uiState.value.copy(passwordChangeError = "비밀번호를 입력해주세요.")
+                return@launch
+            }
+            // 새 비밀번호 일치 여부 검사
+            if (newPassword != newPasswordConfirm) {
+                _uiState.value = _uiState.value.copy(passwordChangeError = "새 비밀번호가 일치하지 않습니다.")
+                return@launch
+            }
+            // 비밀번호 유효성 검사
+            val passwordPattern = "^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#\$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]).{8,20}\$"
+            if (!newPassword.matches(Regex(passwordPattern))) {
+                _uiState.value = _uiState.value.copy(
+                    passwordChangeError = "비밀번호는 8~20자리이며, 알파벳, 숫자, 특수문자를 각각 1개 이상 포함해야 합니다."
+                )
+                return@launch
+            }
+            _uiState.value = _uiState.value.copy(passwordChangeError = null)
+            val result = authUseCase.changePassword(newPassword)
+            when (result) {
+                is NetworkResult.Success -> {
+                    emit(SettingEvent.ShowPasswordChangeSuccessDialog)
+                    _uiState.value = _uiState.value.copy(newPasswordInput = "", newPasswordConfirmInput = "")
+                }
+                is NetworkResult.Error -> {
+                    emit(SettingEvent.ShowPasswordChangeFailureDialog("비밀번호 변경 실패: ${result.message}"))
+                }
+            }
+        }
+    }
+
+    private fun loadNotice() {
+        viewModelScope.launch {
+            val result = settingUseCase.getNotice()
+            if (result is NetworkResult.Success) {
+                _uiState.value = _uiState.value.copy(noticeContent = result.data)
+            } else {
+                _uiState.value = _uiState.value.copy(noticeContent = "공지사항을 불러오는 데 실패했습니다.")
+            }
+            emit(SettingEvent.ShowNoticeDialog)
+        }
+    }
+    private fun loadTerms() {
+        viewModelScope.launch {
+            val result = settingUseCase.getTerms()
+            if (result is NetworkResult.Success) {
+                _uiState.value = _uiState.value.copy(termsContent = result.data)
+            } else {
+                _uiState.value = _uiState.value.copy(termsContent = "서비스 이용약관을 불러오는 데 실패했습니다.")
+            }
+            emit(SettingEvent.ShowTermsDialog)
+        }
+    }
+    private fun loadPrivacyPolicy() {
+        viewModelScope.launch {
+            val result = settingUseCase.getPrivacyPolicy()
+            if (result is NetworkResult.Success) {
+                _uiState.value = _uiState.value.copy(privacyPolicyContent = result.data)
+            } else {
+                _uiState.value = _uiState.value.copy(privacyPolicyContent = "개인정보 처리방침을 불러오는 데 실패했습니다.")
+            }
+            emit(SettingEvent.ShowPrivacyDialog)
+        }
+    }
+
+
 
     private fun emit(event: SettingEvent) {
         _events.tryEmit(event)

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/address/ChangeAddressFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/address/ChangeAddressFragment.kt
@@ -1,7 +1,0 @@
-package com.kau.ttokttok.ui.compose.setting.address
-
-import androidx.fragment.app.Fragment
-
-class ChangeAddressFragment : Fragment() {
-
-}

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/address/changeAddressRoute.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/address/changeAddressRoute.kt
@@ -1,2 +1,0 @@
-package com.kau.ttokttok.ui.compose.setting.address
-

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/address/changeAddressScreen.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/address/changeAddressScreen.kt
@@ -1,2 +1,0 @@
-package com.kau.ttokttok.ui.compose.setting.address
-

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/address/changeAddressViewModel.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/address/changeAddressViewModel.kt
@@ -1,1 +1,0 @@
-package com.kau.ttokttok.ui.compose.setting.address

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/nickname/ChangeNicknameFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/nickname/ChangeNicknameFragment.kt
@@ -1,7 +1,0 @@
-package com.kau.ttokttok.ui.compose.setting.nickname
-
-import androidx.fragment.app.Fragment
-
-class ChangeNicknameFragment : Fragment() {
-
-}

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/nickname/changeNicknameRoute.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/nickname/changeNicknameRoute.kt
@@ -1,2 +1,0 @@
-package com.kau.ttokttok.ui.compose.setting.nickname
-

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/nickname/changeNicknameScreen.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/nickname/changeNicknameScreen.kt
@@ -1,2 +1,0 @@
-package com.kau.ttokttok.ui.compose.setting.nickname
-

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/nickname/changeNicknameViewModel.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/nickname/changeNicknameViewModel.kt
@@ -1,2 +1,0 @@
-package com.kau.ttokttok.ui.compose.setting.nickname
-

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/password/ChangePasswordFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/password/ChangePasswordFragment.kt
@@ -1,7 +1,0 @@
-package com.kau.ttokttok.ui.compose.setting.password
-
-import androidx.fragment.app.Fragment
-
-class ChangePasswordFragment : Fragment() {
-
-}

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/password/changePasswordRoute.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/password/changePasswordRoute.kt
@@ -1,2 +1,0 @@
-package com.kau.ttokttok.ui.compose.setting.password
-

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/password/changePasswordScreen.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/password/changePasswordScreen.kt
@@ -1,2 +1,0 @@
-package com.kau.ttokttok.ui.compose.setting.password
-

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/setting/password/changePasswordViewModel.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/setting/password/changePasswordViewModel.kt
@@ -1,2 +1,0 @@
-package com.kau.ttokttok.ui.compose.setting.password
-


### PR DESCRIPTION
- 로그아웃 및 회원탈퇴 시 JWT 토큰 초기화 로직 생성 완료

- 기존 설정 화면에 존재하던 "닉네임 변경" 삭제

- 거주지 변경과 비밀번호 변경을 다이얼로그 형식으로 변경
(공백, 비밀번호 일치여부, 유효성 검사만 진행하고 항상 비밀번호 변경 성공을 반환) // 백엔드 비밀번호 변경과 연결 x

- 공지사항 / 서비스 이용약관 / 개인정보 처리방침 레포지토리에 연결하고, 데이터는 하드코딩
