### PR TITLE
Feat/noise calendar 소음 측정기 api 연동 및 파일 저장기능 등

### DIFF
--- a/app/src/main/java/com/kau/ttokttok/_core/network/di/NetworkModule.kt
+++ b/app/src/main/java/com/kau/ttokttok/_core/network/di/NetworkModule.kt
@@ -7,6 +7,7 @@ import com.kau.ttokttok.data.remote.api.NoiseCalendarApiService
 import com.kau.ttokttok.data.remote.api.NoiseRecordApiService
 import com.kau.ttokttok.data.remote.api.NoiseStatusBoardApiService
 import com.kau.ttokttok.data.remote.api.PreNoticeApiService
+import com.kau.ttokttok.data.remote.api.RecordingApiService
 import com.kau.ttokttok.data.remote.api.ReportApiService
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -33,8 +34,19 @@ object NetworkModule {
     // ───────────────────────────────
     @Provides
     @Singleton
-    fun provideLogging(): HttpLoggingInterceptor = HttpLoggingInterceptor().apply {
-        level = HttpLoggingInterceptor.Level.BODY
+    fun provideLogging(): HttpLoggingInterceptor {
+        val logger = HttpLoggingInterceptor { message ->
+            // Multipart 바이너리 데이터는 로그에서 제외
+            if (!message.contains("Content-Disposition: form-data") &&
+                !message.contains("ftyp") &&
+                !message.contains("mdat")) {
+                println(message)
+            }
+        }
+        logger.level = HttpLoggingInterceptor.Level.BODY
+        logger.redactHeader("Authorization")
+        logger.redactHeader("Cookie")
+        return logger
     }
 
     // ───────────────────────────────
@@ -147,4 +159,10 @@ object NetworkModule {
     fun provideReportApiService(
         retrofit: Retrofit
     ): ReportApiService = retrofit.create(ReportApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideRecordingApiService(
+        retrofit: Retrofit
+    ): RecordingApiService = retrofit.create(RecordingApiService::class.java)
 }

--- a/app/src/main/java/com/kau/ttokttok/_core/network/di/NetworkModule.kt
+++ b/app/src/main/java/com/kau/ttokttok/_core/network/di/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.kau.ttokttok._core.network.di
 
 import com.kau.ttokttok._core.network.auth.TokenProvider
+import com.kau.ttokttok.data.remote.api.AIApiService
 import com.kau.ttokttok.data.remote.api.AuthApiService
 import com.kau.ttokttok.data.remote.api.CommunityApiService
 import com.kau.ttokttok.data.remote.api.NoiseCalendarApiService
@@ -165,4 +166,10 @@ object NetworkModule {
     fun provideRecordingApiService(
         retrofit: Retrofit
     ): RecordingApiService = retrofit.create(RecordingApiService::class.java)
+
+    @Provides
+    @Singleton
+    fun provideAIApiService(
+        retrofit: Retrofit
+    ): AIApiService = retrofit.create(AIApiService::class.java)
 }

--- a/app/src/main/java/com/kau/ttokttok/_core/network/di/RepositoryModule.kt
+++ b/app/src/main/java/com/kau/ttokttok/_core/network/di/RepositoryModule.kt
@@ -1,5 +1,6 @@
 package com.kau.ttokttok._core.network.di
 
+import com.kau.ttokttok.data.local.repository.AIRepositoryImpl
 import com.kau.ttokttok.data.local.repository.AuthRepositoryImpl
 import com.kau.ttokttok.data.local.repository.CommunityRepositoryImpl
 import com.kau.ttokttok.data.local.repository.NoiseVoteRepositoryImpl
@@ -9,6 +10,7 @@ import com.kau.ttokttok.data.local.repository.PreConsiderationRepositoryImpl
 import com.kau.ttokttok.data.local.repository.ReportRepositoryImpl
 import com.kau.ttokttok.data.local.repository.SettingRepositoryImpl
 import com.kau.ttokttok.data.repository.RecordingRepositoryImpl
+import com.kau.ttokttok.domain.repository.AIRepository
 import com.kau.ttokttok.domain.repository.AuthRepository
 import com.kau.ttokttok.domain.repository.CommunityRepository
 import com.kau.ttokttok.domain.repository.NoiseVoteRepository
@@ -80,4 +82,10 @@ abstract class RepositoryModule {
     abstract fun bindRecordingRepository(
         impl: RecordingRepositoryImpl
     ): RecordingRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindAIRepository(
+        impl: AIRepositoryImpl
+    ): AIRepository
 }

--- a/app/src/main/java/com/kau/ttokttok/_core/network/di/RepositoryModule.kt
+++ b/app/src/main/java/com/kau/ttokttok/_core/network/di/RepositoryModule.kt
@@ -8,12 +8,14 @@ import com.kau.ttokttok.data.local.repository.NotificationRepositoryImpl
 import com.kau.ttokttok.data.local.repository.PreConsiderationRepositoryImpl
 import com.kau.ttokttok.data.local.repository.ReportRepositoryImpl
 import com.kau.ttokttok.data.local.repository.SettingRepositoryImpl
+import com.kau.ttokttok.data.repository.RecordingRepositoryImpl
 import com.kau.ttokttok.domain.repository.AuthRepository
 import com.kau.ttokttok.domain.repository.CommunityRepository
 import com.kau.ttokttok.domain.repository.NoiseVoteRepository
 import com.kau.ttokttok.domain.repository.NoiseLogRepository
 import com.kau.ttokttok.domain.repository.NotificationRepository
 import com.kau.ttokttok.domain.repository.PreConsiderationRepository
+import com.kau.ttokttok.domain.repository.RecordingRepository
 import com.kau.ttokttok.domain.repository.ReportRepository
 import com.kau.ttokttok.domain.repository.SettingRepository
 import dagger.Binds
@@ -72,4 +74,10 @@ abstract class RepositoryModule {
     abstract fun bindsSettingRepository(
         impl: SettingRepositoryImpl
     ): SettingRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindRecordingRepository(
+        impl: RecordingRepositoryImpl
+    ): RecordingRepository
 }

--- a/app/src/main/java/com/kau/ttokttok/data/local/repository/AIRepositoryImpl.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/local/repository/AIRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package com.kau.ttokttok.data.local.repository
+
+import com.kau.ttokttok._core.network.result.NetworkResult
+import com.kau.ttokttok._core.network.result.safeApiCall
+import com.kau.ttokttok.data.remote.api.AIApiService
+import com.kau.ttokttok.data.remote.dto.ai.req.GetAICategoryReq
+import com.kau.ttokttok.data.remote.dto.ai.res.GetAICategoryRes
+import com.kau.ttokttok.domain.repository.AIRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * AI 분석 Repository 구현체
+ */
+@Singleton
+class AIRepositoryImpl @Inject constructor(
+    private val api: AIApiService
+) : AIRepository {
+    /**
+     * AI 카테고리 분석
+     *
+     * @param recordId 녹음 파일 ID
+     * @return AI 분석 결과
+     */
+    override suspend fun getAICategory(recordId: Long): NetworkResult<GetAICategoryRes> =
+        safeApiCall {
+            api.getAICategory(GetAICategoryReq(recordId))
+        }
+}
+

--- a/app/src/main/java/com/kau/ttokttok/data/remote/api/AIApiService.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/api/AIApiService.kt
@@ -1,0 +1,30 @@
+package com.kau.ttokttok.data.remote.api
+
+import com.kau.ttokttok._core.network.model.ApiResponse
+import com.kau.ttokttok.data.remote.dto.ai.req.GetAICategoryReq
+import com.kau.ttokttok.data.remote.dto.ai.res.GetAICategoryRes
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+/**
+ * AI 분석 API Service
+ */
+interface AIApiService {
+    /**
+     * AI 카테고리 분석
+     *
+     * 녹음 파일을 AI가 분석하여 소음 카테고리 자동 판단
+     * - 음성 인식 (transcript)
+     * - 카테고리 분류 (category)
+     * - 판단 이유 (reason)
+     * - 데시벨 정보 (dbMax, dbAvg)
+     *
+     * @param req recordId를 포함한 요청 데이터
+     * @return AI 분석 결과
+     */
+    @POST("noise/ai/category")
+    suspend fun getAICategory(
+        @Body req: GetAICategoryReq
+    ): ApiResponse<GetAICategoryRes>
+}
+

--- a/app/src/main/java/com/kau/ttokttok/data/remote/api/RecordingApiService.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/api/RecordingApiService.kt
@@ -1,0 +1,16 @@
+package com.kau.ttokttok.data.remote.api
+
+import com.kau.ttokttok.data.remote.dto.recording.res.UploadRecordingRes
+import okhttp3.MultipartBody
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+interface RecordingApiService {
+    @Multipart
+    @POST("api/recordings")
+    suspend fun uploadRecording(
+        @Part voiceFile: MultipartBody.Part
+    ): UploadRecordingRes
+}
+

--- a/app/src/main/java/com/kau/ttokttok/data/remote/api/RecordingApiService.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/api/RecordingApiService.kt
@@ -1,5 +1,6 @@
 package com.kau.ttokttok.data.remote.api
 
+import com.kau.ttokttok._core.network.model.ApiResponse
 import com.kau.ttokttok.data.remote.dto.recording.res.UploadRecordingRes
 import okhttp3.MultipartBody
 import retrofit2.http.Multipart
@@ -11,6 +12,6 @@ interface RecordingApiService {
     @POST("api/recordings")
     suspend fun uploadRecording(
         @Part voiceFile: MultipartBody.Part
-    ): UploadRecordingRes
+    ): ApiResponse<UploadRecordingRes>
 }
 

--- a/app/src/main/java/com/kau/ttokttok/data/remote/api/ReportApiService.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/api/ReportApiService.kt
@@ -20,7 +20,12 @@ interface ReportApiService {
         @Query("date") date: String
     ): ApiResponse<GetMonthlyReportRes>
 
-    // 리포트 생성(전송)
+    /**
+     * 소음 일기를 소음현황판으로 전송
+     * - 서버에서 AI가 자동으로 summary(요약) 생성
+     * - description(사용자 메모)을 기반으로 AI 요약 생성
+     * - 생성된 게시글의 ID 반환
+     */
     @POST("noise/records/{recordId}/send")
     suspend fun createReport(
         @Path("recordId") recordId: Long

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/ai/req/GetAICategoryReq.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/ai/req/GetAICategoryReq.kt
@@ -1,0 +1,16 @@
+package com.kau.ttokttok.data.remote.dto.ai.req
+
+import com.squareup.moshi.Json
+
+/**
+ * AI 카테고리 분석 요청 (POST /noise/ai/category)
+ *
+ * 녹음 파일을 AI가 분석하여 소음 카테고리 자동 판단
+ *
+ * @param recordId 음성파일 고유 번호 (녹음 파일 ID)
+ */
+data class GetAICategoryReq(
+    @Json(name = "recordId")
+    val recordId: Long
+)
+

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/ai/res/GetAICategoryRes.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/ai/res/GetAICategoryRes.kt
@@ -1,0 +1,65 @@
+package com.kau.ttokttok.data.remote.dto.ai.res
+
+/**
+ * AI 카테고리 분석 응답 (POST /noise/ai/category)
+ *
+ * AI가 분석한 소음 카테고리 및 상세 정보
+ *
+ * @param category 소음 카테고리 (MUSIC, FOOTSTEPS, HAMMERING, FURNITURE, UNKNOWN)
+ * @param transcript 음성 인식 결과 (예: "음악 소리")
+ * @param reason AI가 해당 카테고리로 판단한 이유
+ * @param createdAt 분석 완료 시각
+ * @param duration 녹음 파일 길이 (초)
+ * @param dbMax 최대 데시벨
+ * @param dbAvg 평균 데시벨
+ */
+data class GetAICategoryRes(
+    val category: String,
+    val transcript: String,
+    val reason: String,
+    val createdAt: String,
+    val duration: Int,
+    val dbMax: Double,
+    val dbAvg: Double
+)
+
+/**
+ * UI에서 사용할 AI 분석 결과 데이터
+ */
+data class AICategoryResult(
+    val category: String,
+    val categoryKorean: String,
+    val transcript: String,
+    val reason: String,
+    val duration: Int,
+    val dbMax: Double,
+    val dbAvg: Double
+)
+
+/**
+ * 카테고리 영문 → 한글 변환
+ */
+fun String.toCategoryKorean(): String = when (this) {
+    "FOOTSTEPS" -> "발걸음"
+    "HAMMERING" -> "망치질"
+    "FURNITURE" -> "가구 끄는 소리"
+    "MUSIC" -> "음악 소리"
+    "UNKNOWN" -> "기타"
+    else -> "알 수 없음"
+}
+
+/**
+ * Response를 UI 데이터로 변환
+ */
+fun GetAICategoryRes.toAICategoryResult(): AICategoryResult {
+    return AICategoryResult(
+        category = category,
+        categoryKorean = category.toCategoryKorean(),
+        transcript = transcript,
+        reason = reason,
+        duration = duration,
+        dbMax = dbMax,
+        dbAvg = dbAvg
+    )
+}
+

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noisecalendar/res/GetDailyCalendarRes.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noisecalendar/res/GetDailyCalendarRes.kt
@@ -1,5 +1,11 @@
 package com.kau.ttokttok.data.remote.dto.noisecalendar.res
 
+import com.kau.ttokttok.domain.model.NoiseLog
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Date
+
 data class GetDailyCalendarRes(
     val userId: Long,
     val year: Int,
@@ -24,4 +30,33 @@ data class DailyCalendarRecord(
     val dbAvg: Double,
     val summary: String?,
     val description: String?  // 등록 시 서버가 description으로 보낼 수 있으므로 추가
-)
+) {
+    /**
+     * Response String 날짜를 Domain 모델로 변환
+     */
+    fun toDomain(): NoiseLog {
+        val measuredDate = parseStringToDate(occuredAt)
+
+        // 메모 우선순위: summary(수정 시) > description(등록 시) > 빈 문자열
+        val memoText = when {
+            !summary.isNullOrBlank() -> summary
+            !description.isNullOrBlank() -> description
+            else -> ""
+        }
+
+        return NoiseLog(
+            id = recordId.toString(),
+            noiseType = category,
+            maxDecibel = dbHigh,
+            avgDecibel = dbAvg,
+            memo = memoText,
+            measuredAt = measuredDate,
+            hasReport = false
+        )
+    }
+
+    private fun parseStringToDate(dateString: String): Date {
+        val localDateTime = LocalDateTime.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        return Date.from(localDateTime.atZone(ZoneOffset.systemDefault()).toInstant())
+    }
+}

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noisecalendar/res/GetDailyCalendarRes.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noisecalendar/res/GetDailyCalendarRes.kt
@@ -28,21 +28,18 @@ data class DailyCalendarRecord(
     val grade: String,
     val dbHigh: Double,
     val dbAvg: Double,
-    val summary: String?,
-    val description: String?  // 등록 시 서버가 description으로 보낼 수 있으므로 추가
+    val description: String?,  // 사용자가 작성한 메모 (소음일기용)
+    val summary: String?       // AI가 자동 생성한 요약 (소음현황판용)
 ) {
     /**
      * Response String 날짜를 Domain 모델로 변환
+     * 소음일기에서는 description 우선 표시
      */
     fun toDomain(): NoiseLog {
         val measuredDate = parseStringToDate(occuredAt)
 
-        // 메모 우선순위: summary(수정 시) > description(등록 시) > 빈 문자열
-        val memoText = when {
-            !summary.isNullOrBlank() -> summary
-            !description.isNullOrBlank() -> description
-            else -> ""
-        }
+        // 소음일기는 사용자가 작성한 description을 표시
+        val memoText = description ?: ""
 
         return NoiseLog(
             id = recordId.toString(),

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noisecalendar/res/GetDailyCalendarRes.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noisecalendar/res/GetDailyCalendarRes.kt
@@ -29,7 +29,8 @@ data class DailyCalendarRecord(
     val dbHigh: Double,
     val dbAvg: Double,
     val description: String?,  // 사용자가 작성한 메모 (소음일기용)
-    val summary: String?       // AI가 자동 생성한 요약 (소음현황판용)
+    val summary: String?,      // AI가 자동 생성한 요약 (소음현황판용)
+    val hasReport: Boolean = false // ✅ 서버에서 리포트 생성 여부를 내려줄 경우 사용, 없으면 기본값 false
 ) {
     /**
      * Response String 날짜를 Domain 모델로 변환
@@ -38,7 +39,7 @@ data class DailyCalendarRecord(
     fun toDomain(): NoiseLog {
         val measuredDate = parseStringToDate(occuredAt)
 
-        // 소음일기는 사용자가 작성한 description을 표시
+        // 소음일기는 사용자가 작성한 description을 메모로 사용
         val memoText = description ?: ""
 
         return NoiseLog(
@@ -48,7 +49,7 @@ data class DailyCalendarRecord(
             avgDecibel = dbAvg,
             memo = memoText,
             measuredAt = measuredDate,
-            hasReport = false
+            hasReport = hasReport
         )
     }
 

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/req/CreateNoiseRecordReq.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/req/CreateNoiseRecordReq.kt
@@ -1,5 +1,11 @@
 package com.kau.ttokttok.data.remote.dto.noiserecord.req
 
+import com.kau.ttokttok.domain.model.NoiseLog
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Date
+
 data class CreateNoiseRecordReq(
     val occuredAt: String,   // ISO-8601 (e.g., 2025-11-09T11:32:57.272Z)
     val duration: Int,
@@ -10,4 +16,45 @@ data class CreateNoiseRecordReq(
     val description: String,
     // 서버가 텍스트 메모를 summary로 저장할 수 있도록 등록 시에도 함께 전달
     val summary: String?
-)
+) {
+    companion object {
+        /**
+         * Domain 모델로부터 Request 생성 (Date → String 변환)
+         */
+        fun from(noiseLog: NoiseLog): CreateNoiseRecordReq {
+            return CreateNoiseRecordReq(
+                occuredAt = formatDateToString(noiseLog.measuredAt),
+                duration = noiseLog.duration.toInt(),
+                dbHigh = noiseLog.maxDecibel,
+                dbAvg = noiseLog.avgDecibel,
+                category = mapCategory(noiseLog.noiseType),
+                grade = mapGrade(noiseLog.avgDecibel),
+                description = noiseLog.memo,
+                summary = noiseLog.memo
+            )
+        }
+
+        private fun formatDateToString(date: Date): String {
+            return Instant.ofEpochMilli(date.time)
+                .atOffset(ZoneOffset.systemDefault().rules.getOffset(Instant.ofEpochMilli(date.time)))
+                .toLocalDateTime()
+                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        }
+
+        private fun mapCategory(noiseType: String): String = when (noiseType.uppercase()) {
+            "FOOTSTEPS", "발걸음" -> "FOOTSTEPS"
+            "HAMMERING", "망치질" -> "HAMMERING"
+            "FURNITURE", "가구 끄는 소리", "가구" -> "FURNITURE"
+            "MUSIC", "음악 소리", "음악" -> "MUSIC"
+            "KIDS", "아이들 뛰는 소리" -> "UNKNOWN"
+            "VACUUM", "청소기 소리" -> "UNKNOWN"
+            else -> "UNKNOWN"
+        }
+
+        private fun mapGrade(avg: Double): String = when {
+            avg >= 65 -> "LOUD"
+            avg >= 45 -> "NORMAL"
+            else -> "QUIET"
+        }
+    }
+}

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/req/CreateNoiseRecordReq.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/req/CreateNoiseRecordReq.kt
@@ -13,9 +13,7 @@ data class CreateNoiseRecordReq(
     val dbAvg: Double,
     val category: String,    // FOOTSTEPS, HAMMERING, FURNITURE, MUSIC, UNKNOWN
     val grade: String,       // QUIET, NORMAL, LOUD
-    val description: String,
-    // 서버가 텍스트 메모를 summary로 저장할 수 있도록 등록 시에도 함께 전달
-    val summary: String?
+    val description: String  // 사용자가 작성한 메모 (소음일기용)
 ) {
     companion object {
         /**
@@ -29,8 +27,7 @@ data class CreateNoiseRecordReq(
                 dbAvg = noiseLog.avgDecibel,
                 category = mapCategory(noiseLog.noiseType),
                 grade = mapGrade(noiseLog.avgDecibel),
-                description = noiseLog.memo,
-                summary = noiseLog.memo
+                description = noiseLog.memo
             )
         }
 

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/req/ModifyNoiseRecordReq.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/req/ModifyNoiseRecordReq.kt
@@ -1,5 +1,11 @@
 package com.kau.ttokttok.data.remote.dto.noiserecord.req
 
+import com.kau.ttokttok.domain.model.NoiseLog
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Date
+
 data class ModifyNoiseRecordReq(
     val category: String,
     val occuredAt: String,
@@ -7,5 +13,44 @@ data class ModifyNoiseRecordReq(
     val dbHigh: Double,
     val dbAvg: Double,
     val summary: String?
-)
+) {
+    companion object {
+        /**
+         * Domain 모델로부터 Request 생성 (Date → String 변환)
+         */
+        fun from(noiseLog: NoiseLog): ModifyNoiseRecordReq {
+            return ModifyNoiseRecordReq(
+                category = mapCategory(noiseLog.noiseType),
+                occuredAt = formatDateToString(noiseLog.measuredAt),
+                noiseGrade = mapGrade(noiseLog.avgDecibel),
+                dbHigh = noiseLog.maxDecibel,
+                dbAvg = noiseLog.avgDecibel,
+                summary = noiseLog.memo
+            )
+        }
+
+        private fun formatDateToString(date: Date): String {
+            return Instant.ofEpochMilli(date.time)
+                .atOffset(ZoneOffset.systemDefault().rules.getOffset(Instant.ofEpochMilli(date.time)))
+                .toLocalDateTime()
+                .format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        }
+
+        private fun mapCategory(noiseType: String): String = when (noiseType.uppercase()) {
+            "FOOTSTEPS", "발걸음" -> "FOOTSTEPS"
+            "HAMMERING", "망치질" -> "HAMMERING"
+            "FURNITURE", "가구 끄는 소리", "가구" -> "FURNITURE"
+            "MUSIC", "음악 소리", "음악" -> "MUSIC"
+            "KIDS", "아이들 뛰는 소리" -> "UNKNOWN"
+            "VACUUM", "청소기 소리" -> "UNKNOWN"
+            else -> "UNKNOWN"
+        }
+
+        private fun mapGrade(avg: Double): String = when {
+            avg >= 65 -> "LOUD"
+            avg >= 45 -> "NORMAL"
+            else -> "QUIET"
+        }
+    }
+}
 

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/req/ModifyNoiseRecordReq.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/req/ModifyNoiseRecordReq.kt
@@ -12,7 +12,7 @@ data class ModifyNoiseRecordReq(
     val noiseGrade: String,
     val dbHigh: Double,
     val dbAvg: Double,
-    val summary: String?
+    val description: String?  // 사용자가 작성한 메모 (소음일기용)
 ) {
     companion object {
         /**
@@ -25,7 +25,7 @@ data class ModifyNoiseRecordReq(
                 noiseGrade = mapGrade(noiseLog.avgDecibel),
                 dbHigh = noiseLog.maxDecibel,
                 dbAvg = noiseLog.avgDecibel,
-                summary = noiseLog.memo
+                description = noiseLog.memo
             )
         }
 

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/res/CreateNoiseRecordRes.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/res/CreateNoiseRecordRes.kt
@@ -1,5 +1,11 @@
 package com.kau.ttokttok.data.remote.dto.noiserecord.res
 
+import com.kau.ttokttok.domain.model.NoiseLog
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Date
+
 data class CreateNoiseRecordRes(
     val id: Long,
     val userId: Long,
@@ -13,4 +19,28 @@ data class CreateNoiseRecordRes(
     // 서버에서 LocalDateTime 문자열을 내려주므로, Moshi 커스텀 어댑터 없이 String으로 수신
     val occuredAt: String,
     val updateAt: String
-)
+) {
+    /**
+     * Response String 날짜를 Domain 모델로 변환
+     */
+    fun toDomain(): NoiseLog {
+        val measuredDate = parseStringToDate(occuredAt)
+        val memoText = summary ?: description ?: ""
+
+        return NoiseLog(
+            id = id.toString(),
+            noiseType = category,
+            maxDecibel = dbHigh,
+            avgDecibel = dbAvg,
+            memo = memoText,
+            measuredAt = measuredDate,
+            duration = duration.toLong(),
+            hasReport = false
+        )
+    }
+
+    private fun parseStringToDate(dateString: String): Date {
+        val localDateTime = LocalDateTime.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        return Date.from(localDateTime.atZone(ZoneOffset.systemDefault()).toInstant())
+    }
+}

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/res/CreateNoiseRecordRes.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/res/CreateNoiseRecordRes.kt
@@ -14,18 +14,19 @@ data class CreateNoiseRecordRes(
     val dbAvg: Double,
     val category: String,
     val grade: String,
-    val description: String?,
-    val summary: String?,
+    val description: String?,  // 사용자가 작성한 메모 (소음일기용)
+    val summary: String?,      // AI가 자동 생성한 요약 (소음현황판용, 전송 시 생성됨)
     // 서버에서 LocalDateTime 문자열을 내려주므로, Moshi 커스텀 어댑터 없이 String으로 수신
     val occuredAt: String,
     val updateAt: String
 ) {
     /**
      * Response String 날짜를 Domain 모델로 변환
+     * 소음일기에서는 description 우선 표시
      */
     fun toDomain(): NoiseLog {
         val measuredDate = parseStringToDate(occuredAt)
-        val memoText = summary ?: description ?: ""
+        val memoText = description ?: ""
 
         return NoiseLog(
             id = id.toString(),

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/res/CreateNoiseRecordRes.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/res/CreateNoiseRecordRes.kt
@@ -18,7 +18,8 @@ data class CreateNoiseRecordRes(
     val summary: String?,      // AI가 자동 생성한 요약 (소음현황판용, 전송 시 생성됨)
     // 서버에서 LocalDateTime 문자열을 내려주므로, Moshi 커스텀 어댑터 없이 String으로 수신
     val occuredAt: String,
-    val updateAt: String
+    val updateAt: String,
+    val hasReport: Boolean = false // ✅ 서버에서 리포트 생성 여부를 내려줄 경우 사용, 기본값 false
 ) {
     /**
      * Response String 날짜를 Domain 모델로 변환
@@ -36,7 +37,7 @@ data class CreateNoiseRecordRes(
             memo = memoText,
             measuredAt = measuredDate,
             duration = duration.toLong(),
-            hasReport = false
+            hasReport = hasReport
         )
     }
 

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/res/ModifyNoiseRecordRes.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/res/ModifyNoiseRecordRes.kt
@@ -18,7 +18,8 @@ data class ModifyNoiseRecordRes(
     val dbAvg: Double,
     val description: String?,  // 사용자가 작성한 메모 (소음일기용)
     val summary: String?,      // AI가 자동 생성한 요약 (소음현황판용, 전송 시 생성됨)
-    val updatedAt: String
+    val updatedAt: String,
+    val hasReport: Boolean = false // ✅ 서버에서 리포트 여부를 내려줄 수 있도록 필드 추가 (기본값 false)
 ) {
     /**
      * Response String 날짜를 Domain 모델로 변환
@@ -34,7 +35,7 @@ data class ModifyNoiseRecordRes(
             avgDecibel = dbAvg,
             memo = description ?: "",
             measuredAt = measuredDate,
-            hasReport = false
+            hasReport = hasReport
         )
     }
 

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/res/ModifyNoiseRecordRes.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/res/ModifyNoiseRecordRes.kt
@@ -16,11 +16,13 @@ data class ModifyNoiseRecordRes(
     val noiseGrade: String,
     val dbHigh: Double,
     val dbAvg: Double,
-    val summary: String,
+    val description: String?,  // 사용자가 작성한 메모 (소음일기용)
+    val summary: String?,      // AI가 자동 생성한 요약 (소음현황판용, 전송 시 생성됨)
     val updatedAt: String
 ) {
     /**
      * Response String 날짜를 Domain 모델로 변환
+     * 소음일기에서는 description 우선 표시
      */
     fun toDomain(): NoiseLog {
         val measuredDate = parseStringToDate(occuredAt)
@@ -30,7 +32,7 @@ data class ModifyNoiseRecordRes(
             noiseType = category,
             maxDecibel = dbHigh,
             avgDecibel = dbAvg,
-            memo = summary,
+            memo = description ?: "",
             measuredAt = measuredDate,
             hasReport = false
         )

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/res/ModifyNoiseRecordRes.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/noiserecord/res/ModifyNoiseRecordRes.kt
@@ -1,5 +1,11 @@
 package com.kau.ttokttok.data.remote.dto.noiserecord.res
 
+import com.kau.ttokttok.domain.model.NoiseLog
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Date
+
 data class ModifyNoiseRecordRes(
     val noiseId: Long,
     // TODO: 추후 Enum으로 변경
@@ -12,4 +18,26 @@ data class ModifyNoiseRecordRes(
     val dbAvg: Double,
     val summary: String,
     val updatedAt: String
-)
+) {
+    /**
+     * Response String 날짜를 Domain 모델로 변환
+     */
+    fun toDomain(): NoiseLog {
+        val measuredDate = parseStringToDate(occuredAt)
+
+        return NoiseLog(
+            id = noiseId.toString(),
+            noiseType = category,
+            maxDecibel = dbHigh,
+            avgDecibel = dbAvg,
+            memo = summary,
+            measuredAt = measuredDate,
+            hasReport = false
+        )
+    }
+
+    private fun parseStringToDate(dateString: String): Date {
+        val localDateTime = LocalDateTime.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        return Date.from(localDateTime.atZone(ZoneOffset.systemDefault()).toInstant())
+    }
+}

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/recording/res/UploadRecordingRes.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/recording/res/UploadRecordingRes.kt
@@ -1,0 +1,15 @@
+package com.kau.ttokttok.data.remote.dto.recording.res
+
+import com.squareup.moshi.Json
+
+data class UploadRecordingRes(
+    @Json(name = "recordingId")
+    val recordingId: Long,
+
+    @Json(name = "fileUrl")
+    val fileUrl: String,
+
+    @Json(name = "createdAt")
+    val createdAt: String
+)
+

--- a/app/src/main/java/com/kau/ttokttok/data/remote/dto/report/res/CreateReportRes.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/remote/dto/report/res/CreateReportRes.kt
@@ -1,6 +1,18 @@
 package com.kau.ttokttok.data.remote.dto.report.res
 
-// 소음 기록 전송 응답 (POST /noise/records/{recordId}/send)
-// result는 전송된 소음현황 게시글의 ID
+/**
+ * 소음 일기 → 소음현황판 전송 응답 (POST /noise/records/{recordId}/send)
+ *
+ * 백엔드 동작:
+ * 1. 소음 일기의 description(사용자 메모)을 기반으로 AI가 summary(요약) 자동 생성
+ *    예: "아 음악소리좀 제발 너무 시끄러워"
+ *    → "11월 29일 22:40경, 60초간 악기/음악 소음 발생"
+ *
+ * 2. 생성된 summary와 함께 소음현황판에 게시글 생성
+ *
+ * 3. 생성된 게시글 ID 반환
+ *
+ * @return 소음현황판에 생성된 게시글의 ID
+ */
 typealias CreateReportRes = Long
 

--- a/app/src/main/java/com/kau/ttokttok/data/repository/RecordingRepositoryImpl.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/repository/RecordingRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.kau.ttokttok.data.repository
+
+import com.kau.ttokttok.data.remote.api.RecordingApiService
+import com.kau.ttokttok.data.remote.dto.recording.res.UploadRecordingRes
+import com.kau.ttokttok.domain.repository.RecordingRepository
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import java.io.File
+import javax.inject.Inject
+
+class RecordingRepositoryImpl @Inject constructor(
+    private val recordingApiService: RecordingApiService
+) : RecordingRepository {
+
+    override suspend fun uploadRecording(file: File): Result<UploadRecordingRes> {
+        return try {
+            // AAC/M4A 오디오 파일로 전송
+            val requestFile = file.asRequestBody("audio/aac".toMediaTypeOrNull())
+            val multipartBody = MultipartBody.Part.createFormData("voiceFile", file.name, requestFile)
+
+            val response = recordingApiService.uploadRecording(multipartBody)
+            Result.success(response)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}
+

--- a/app/src/main/java/com/kau/ttokttok/data/repository/RecordingRepositoryImpl.kt
+++ b/app/src/main/java/com/kau/ttokttok/data/repository/RecordingRepositoryImpl.kt
@@ -19,8 +19,14 @@ class RecordingRepositoryImpl @Inject constructor(
             val requestFile = file.asRequestBody("audio/aac".toMediaTypeOrNull())
             val multipartBody = MultipartBody.Part.createFormData("voiceFile", file.name, requestFile)
 
-            val response = recordingApiService.uploadRecording(multipartBody)
-            Result.success(response)
+            val apiResponse = recordingApiService.uploadRecording(multipartBody)
+
+            // ApiResponse 래퍼를 벗겨서 처리
+            if (apiResponse.isSuccess && apiResponse.result != null) {
+                Result.success(apiResponse.result)
+            } else {
+                Result.failure(Exception("업로드 실패: ${apiResponse.message}"))
+            }
         } catch (e: Exception) {
             Result.failure(e)
         }

--- a/app/src/main/java/com/kau/ttokttok/domain/repository/AIRepository.kt
+++ b/app/src/main/java/com/kau/ttokttok/domain/repository/AIRepository.kt
@@ -1,0 +1,18 @@
+package com.kau.ttokttok.domain.repository
+
+import com.kau.ttokttok._core.network.result.NetworkResult
+import com.kau.ttokttok.data.remote.dto.ai.res.GetAICategoryRes
+
+/**
+ * AI 분석 Repository
+ */
+interface AIRepository {
+    /**
+     * AI 카테고리 분석
+     *
+     * @param recordId 녹음 파일 ID
+     * @return AI 분석 결과
+     */
+    suspend fun getAICategory(recordId: Long): NetworkResult<GetAICategoryRes>
+}
+

--- a/app/src/main/java/com/kau/ttokttok/domain/repository/RecordingRepository.kt
+++ b/app/src/main/java/com/kau/ttokttok/domain/repository/RecordingRepository.kt
@@ -1,0 +1,9 @@
+package com.kau.ttokttok.domain.repository
+
+import com.kau.ttokttok.data.remote.dto.recording.res.UploadRecordingRes
+import java.io.File
+
+interface RecordingRepository {
+    suspend fun uploadRecording(file: File): Result<UploadRecordingRes>
+}
+

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/noisevote/NoiseVoteViewModel.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/noisevote/NoiseVoteViewModel.kt
@@ -1,5 +1,6 @@
 package com.kau.ttokttok.ui.compose.noisevote
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kau.ttokttok._core.network.result.NetworkResult
@@ -23,9 +24,23 @@ class NoiseVoteViewModel @Inject constructor(
 
     fun loadPosts() {
         viewModelScope.launch {
+            Log.d("NoiseVoteViewModel", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+            Log.d("NoiseVoteViewModel", "소음현황판 데이터 로딩 시작")
+            Log.d("NoiseVoteViewModel", "요청 URL: GET /api/noise-reports")
+
             when (val result = repository.getPosts()) {
                 is NetworkResult.Success -> {
+                    Log.d("NoiseVoteViewModel", "✅ 소음현황판 데이터 로딩 성공!")
+                    Log.d("NoiseVoteViewModel", "  - 전체 게시글 수: ${result.data.reports.size}개")
+                    Log.d("NoiseVoteViewModel", "  - 페이지 정보: ${result.data.listSize}개 (${result.data.totalElements}개 중)")
+
                     val uiPosts = result.data.reports.map { dto ->
+                        Log.d("NoiseVoteViewModel", "  📋 게시글 ID: ${dto.reportId}")
+                        Log.d("NoiseVoteViewModel", "    - 작성자: ${dto.authorDong}동")
+                        Log.d("NoiseVoteViewModel", "    - Summary: ${dto.summary}")
+                        Log.d("NoiseVoteViewModel", "    - 작성일: ${dto.reportedAt}")
+                        Log.d("NoiseVoteViewModel", "    - 카테고리: ${dto.category}")
+
                         NoiseReport(
                             id = dto.reportId,
                             authorLocation = String.format("%s동", dto.authorDong),
@@ -34,12 +49,21 @@ class NoiseVoteViewModel @Inject constructor(
                     }
 
                     _posts.value = uiPosts
+                    Log.d("NoiseVoteViewModel", "소음현황판 UI 업데이트 완료 (${uiPosts.size}개)")
                 }
 
                 is NetworkResult.Error -> {
+                    Log.e("NoiseVoteViewModel", "❌ 소음현황판 데이터 로딩 실패!")
+                    Log.e("NoiseVoteViewModel", "  - HTTP 코드: ${result.code}")
+                    Log.e("NoiseVoteViewModel", "  - 에러 메시지: ${result.message}")
+                    result.exception?.let {
+                        Log.e("NoiseVoteViewModel", "  - Exception: ${it.message}", it)
+                    }
                     _posts.value = emptyList()
                 }
             }
+
+            Log.d("NoiseVoteViewModel", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
         }
     }
 }

--- a/app/src/main/java/com/kau/ttokttok/ui/compose/noisevote/detail/NoiseVoteDetailViewModel.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/compose/noisevote/detail/NoiseVoteDetailViewModel.kt
@@ -39,8 +39,23 @@ class NoiseVoteDetailViewModel @Inject constructor(
 
     fun loadPostDetail() {
         viewModelScope.launch {
+            Log.d("NoiseVoteDetailViewModel", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+            Log.d("NoiseVoteDetailViewModel", "소음현황판 상세 데이터 로딩 시작")
+            Log.d("NoiseVoteDetailViewModel", "요청 URL: GET /api/noise-reports/$noiseVoteId")
+
             when (val result = repository.getPostDetail(noiseVoteId)) {
                 is NetworkResult.Success -> {
+                    Log.d("NoiseVoteDetailViewModel", "✅ 소음현황판 상세 데이터 로딩 성공!")
+                    Log.d("NoiseVoteDetailViewModel", "  - 게시글 ID: ${result.data.reportId}")
+                    Log.d("NoiseVoteDetailViewModel", "  - Summary(AI 요약): ${result.data.summary}")
+                    Log.d("NoiseVoteDetailViewModel", "  - 작성자: ${result.data.authorDong}동")
+                    Log.d("NoiseVoteDetailViewModel", "  - 작성일: ${result.data.reportedAt}")
+                    Log.d("NoiseVoteDetailViewModel", "  - 카테고리: ${result.data.category}")
+                    Log.d("NoiseVoteDetailViewModel", "  - 투표 수 - 들었어요: ${result.data.voteCounts.HEARD}")
+                    Log.d("NoiseVoteDetailViewModel", "  - 투표 수 - 못들었어요: ${result.data.voteCounts.NOT_HEARD}")
+                    Log.d("NoiseVoteDetailViewModel", "  - 투표 수 - 조심할게요: ${result.data.voteCounts.BE_CAREFUL}")
+                    Log.d("NoiseVoteDetailViewModel", "  - 댓글 수: ${result.data.comments.size}개")
+
                     val title = result.data.summary
                     val buildingNumber = result.data.authorDong
                     val reportedAt = result.data.reportedAt
@@ -56,12 +71,22 @@ class NoiseVoteDetailViewModel @Inject constructor(
                         voteCount = voteCount,
                         comments = comments
                     )
+
+                    Log.d("NoiseVoteDetailViewModel", "소음현황판 상세 UI 업데이트 완료")
                 }
 
                 is NetworkResult.Error -> {
+                    Log.e("NoiseVoteDetailViewModel", "❌ 소음현황판 상세 데이터 로딩 실패!")
+                    Log.e("NoiseVoteDetailViewModel", "  - HTTP 코드: ${result.code}")
+                    Log.e("NoiseVoteDetailViewModel", "  - 에러 메시지: ${result.message}")
+                    result.exception?.let {
+                        Log.e("NoiseVoteDetailViewModel", "  - Exception: ${it.message}", it)
+                    }
                     _uiState.value = NoiseVoteDetailUiState()
                 }
             }
+
+            Log.d("NoiseVoteDetailViewModel", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
         }
     }
 }

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogFormFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogFormFragment.kt
@@ -1,6 +1,7 @@
 package com.kau.ttokttok.ui.xml.calendar
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -8,15 +9,21 @@ import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.button.MaterialButton
 import com.kau.ttokttok.R
+import com.kau.ttokttok._core.network.result.NetworkResult
 import com.kau.ttokttok.databinding.FragmentNoiseLogFormBinding
+import com.kau.ttokttok.data.remote.dto.ai.res.toCategoryKorean
 import com.kau.ttokttok.domain.model.NoiseLog
+import com.kau.ttokttok.domain.repository.AIRepository
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class NoiseLogFormFragment : Fragment() {
@@ -26,13 +33,17 @@ class NoiseLogFormFragment : Fragment() {
 
     private val viewModel: NoiseLogViewModel by activityViewModels()
 
+    @Inject
+    lateinit var aiRepository: AIRepository
+
     // 측정 데이터
-    private var logId: String? = null // 수정 모드일 때 로그 ID
-    private var isEditMode = false // 수정 모드 여부
+    private var logId: String? = null
+    private var isEditMode = false
     private var maxDb = 0.0
     private var avgDb = 0.0
     private var duration = 0L
     private var measuredAt = Date()
+    private var recordId: Long? = null // 녹음 파일 ID (AI 분석용)
 
     private var selectedNoiseType: String? = null
     private val noiseTypeButtonMap = mutableMapOf<String, MaterialButton>()
@@ -46,6 +57,14 @@ class NoiseLogFormFragment : Fragment() {
             avgDb = it.getDouble(ARG_AVG_DB, 0.0)
             duration = it.getLong(ARG_DURATION, 0)
             measuredAt = Date(it.getLong(ARG_MEASURED_AT, System.currentTimeMillis()))
+            // ✅ NoiseMeasurementFragment 에서 넣어준 record_id 읽기
+            val rawRecordId = it.getLong(ARG_RECORD_ID, -1L)
+            recordId = rawRecordId.takeIf { id -> id != -1L }
+
+            Log.d("NoiseLogFormFragment", "🔍 onCreate - arguments 확인")
+            Log.d("NoiseLogFormFragment", "  - ARG_RECORD_ID(raw): $rawRecordId")
+            Log.d("NoiseLogFormFragment", "  - recordId: $recordId")
+            Log.d("NoiseLogFormFragment", "  - isEditMode: $isEditMode")
 
             // 수정 모드일 때 기존 데이터 불러오기
             if (isEditMode) {
@@ -78,10 +97,32 @@ class NoiseLogFormFragment : Fragment() {
                 binding.etMemo.setText(memo)
                 selectedNoiseType?.let { type -> selectNoiseType(type) }
             }
+        } else {
+            // 신규 등록 모드: AI 카테고리 자동 분석
+            recordId?.let { id ->
+                Log.d("NoiseLogFormFragment", "")
+                Log.d("NoiseLogFormFragment", "🎯 recordId 발견! AI 자동 분석 시작")
+                Log.d("NoiseLogFormFragment", "  - recordId: $id")
+                analyzeAICategory(id)
+            } ?: run {
+                Log.w("NoiseLogFormFragment", "")
+                Log.w("NoiseLogFormFragment", "⚠️ recordId가 null입니다!")
+                Log.w("NoiseLogFormFragment", "  - AI 분석을 건너뜁니다")
+                Log.w("NoiseLogFormFragment", "  - 사용자가 직접 소음 유형을 선택해야 합니다")
+                binding.tvAiSuggested.text = "직접 선택"
+            }
         }
     }
 
     private fun setupUI() {
+        Log.d("NoiseLogFormFragment", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+        Log.d("NoiseLogFormFragment", "📋 소음일기 작성 화면 초기화")
+        Log.d("NoiseLogFormFragment", "  - 수정 모드: $isEditMode")
+        Log.d("NoiseLogFormFragment", "  - 최대 데시벨: $maxDb dB")
+        Log.d("NoiseLogFormFragment", "  - 평균 데시벨: $avgDb dB")
+        Log.d("NoiseLogFormFragment", "  - 측정 시간: $duration 초")
+        Log.d("NoiseLogFormFragment", "  - recordId: $recordId")
+
         val dateFormat = SimpleDateFormat("MM월 dd일 HH:mm", Locale.KOREAN)
         binding.tvMeasuredTime.text = dateFormat.format(measuredAt)
 
@@ -96,14 +137,18 @@ class NoiseLogFormFragment : Fragment() {
         binding.tvMaxNoise.text = "${maxDb.toInt()}dB"
         binding.tvAvgNoise.text = "${avgDb.toInt()}dB"
 
-        val suggestedType = getSuggestedNoiseType(avgDb)
-        binding.tvAiSuggested.text = suggestedType
-        binding.tvAiSuggested.setOnClickListener {
-            selectNoiseType(suggestedType)
+        // AI 분석 중 표시
+        if (!isEditMode && recordId != null) {
+            binding.tvAiSuggested.text = "AI 분석 중..."
         }
+
+        Log.d("NoiseLogFormFragment", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
     }
 
     private fun setupNoiseTypeButtons() {
+        android.util.Log.d("NoiseLogFormFragment", "")
+        android.util.Log.d("NoiseLogFormFragment", "🔘 소음 유형 버튼 초기화")
+
         // 버튼과 타입을 맵으로 관리
         noiseTypeButtonMap.apply {
             put("발걸음", binding.chipStep)
@@ -115,10 +160,21 @@ class NoiseLogFormFragment : Fragment() {
             put("기타", binding.chipEtc)
         }
 
+        android.util.Log.d("NoiseLogFormFragment", "  - 등록된 버튼 수: ${noiseTypeButtonMap.size}개")
+        noiseTypeButtonMap.keys.forEach { type ->
+            android.util.Log.d("NoiseLogFormFragment", "    · $type")
+        }
+
         // 각 버튼에 클릭 리스너 설정
         noiseTypeButtonMap.forEach { (type, button) ->
-            button.setOnClickListener { selectNoiseType(type) }
+            button.setOnClickListener {
+                android.util.Log.d("NoiseLogFormFragment", "")
+                android.util.Log.d("NoiseLogFormFragment", "👆 사용자가 \"$type\" 버튼 클릭")
+                selectNoiseType(type)
+            }
         }
+
+        android.util.Log.d("NoiseLogFormFragment", "  - 클릭 리스너 설정 완료")
     }
 
     private fun setupListeners() {
@@ -136,6 +192,10 @@ class NoiseLogFormFragment : Fragment() {
     }
 
     private fun selectNoiseType(type: String) {
+        Log.d("NoiseLogFormFragment", "")
+        Log.d("NoiseLogFormFragment", "✅ 소음 유형 선택: $type")
+        Log.d("NoiseLogFormFragment", "  - 이전 선택: $selectedNoiseType")
+
         selectedNoiseType = type
 
         // 모든 버튼 초기화 후 선택된 버튼만 강조
@@ -149,16 +209,81 @@ class NoiseLogFormFragment : Fragment() {
         noiseTypeButtonMap[type]?.apply {
             strokeColor = ContextCompat.getColorStateList(requireContext(), R.color.colorPrimary)
             strokeWidth = 4
+            Log.d("NoiseLogFormFragment", "  - UI 업데이트: \"$type\" 버튼 강조 완료")
+        } ?: run {
+            Log.e("NoiseLogFormFragment", "  ⚠️ 경고: \"$type\" 버튼을 찾을 수 없음!")
+            Log.e("NoiseLogFormFragment", "  - 등록된 버튼: ${noiseTypeButtonMap.keys}")
         }
+
+        Log.d("NoiseLogFormFragment", "  - 현재 선택: $selectedNoiseType")
     }
 
-    private fun getSuggestedNoiseType(avgDb: Double): String = when {
-        avgDb >= 60.0 -> "망치질"
-        avgDb >= 50.0 -> "가구 끄는 소리"
-        avgDb >= 45.0 -> "아이들 뛰는 소리"
-        avgDb >= 40.0 -> "발걸음"
-        avgDb >= 35.0 -> "음악 소리"
-        else -> "청소기 소리"
+    /**
+     * AI 카테고리 자동 분석
+     * 녹음 파일을 서버 AI가 분석하여 소음 종류 판단
+     */
+    private fun analyzeAICategory(recordId: Long) {
+        Log.d("NoiseLogFormFragment", "")
+        Log.d("NoiseLogFormFragment", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+        Log.d("NoiseLogFormFragment", "🤖 AI 카테고리 분석 시작")
+        Log.d("NoiseLogFormFragment", "  - recordId: $recordId")
+        Log.d("NoiseLogFormFragment", "  - API: POST /noise/ai/category")
+
+        // 로딩 표시
+        binding.tvAiSuggested.text = "AI 분석 중..."
+
+        viewLifecycleOwner. lifecycleScope.launch {
+            when (val result = aiRepository.getAICategory(recordId)) {
+                is NetworkResult.Success -> {
+                    val aiResult = result.data
+                    val categoryKorean = aiResult.category.toCategoryKorean()
+
+                    Log.d("NoiseLogFormFragment", "✅ AI 분석 성공!")
+                    Log.d("NoiseLogFormFragment", "  - 카테고리: $categoryKorean (${aiResult.category})")
+                    Log.d("NoiseLogFormFragment", "  - 음성 인식: ${aiResult.transcript}")
+                    Log.d("NoiseLogFormFragment", "  - 분석 이유: ${aiResult.reason}")
+                    Log.d("NoiseLogFormFragment", "  - 최대 데시벨: ${aiResult.dbMax}dB")
+                    Log.d("NoiseLogFormFragment", "  - 평균 데시벨: ${aiResult.dbAvg}dB")
+                    Log.d("NoiseLogFormFragment", "  - 측정 시간: ${aiResult.duration}초")
+
+                    // UI 업데이트
+                    binding.tvAiSuggested.text = categoryKorean
+
+                    // 🎯 자동으로 카테고리 선택
+                    Log.d("NoiseLogFormFragment", "  - 🤖 AI 추천 카테고리 자동 선택: $categoryKorean")
+                    selectNoiseType(categoryKorean)
+
+                    // AI 추천 텍스트 클릭 시 분석 이유 표시
+                    binding.tvAiSuggested.setOnClickListener {
+                        Toast.makeText(
+                            requireContext(),
+                            "AI 분석 이유: ${aiResult.reason}",
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
+
+                    Log.d("NoiseLogFormFragment", "  - UI 업데이트 완료")
+                }
+
+                is NetworkResult.Error -> {
+                    Log.e("NoiseLogFormFragment", "❌ AI 분석 실패!")
+                    Log.e("NoiseLogFormFragment", "  - 에러 코드: ${result.code}")
+                    Log.e("NoiseLogFormFragment", "  - 에러 메시지: ${result.message}")
+
+                    // 실패 시 기본 메시지
+                    binding.tvAiSuggested.text = "AI 분석 실패"
+                    binding.tvAiSuggested.setOnClickListener(null)
+
+                    Toast.makeText(
+                        requireContext(),
+                        "AI 분석에 실패했습니다. 직접 선택해주세요.",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
+
+            Log.d("NoiseLogFormFragment", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+        }
     }
 
     private fun validateInput(): Boolean {
@@ -221,6 +346,7 @@ class NoiseLogFormFragment : Fragment() {
         private const val ARG_AVG_DB = "avg_db"
         private const val ARG_DURATION = "duration"
         private const val ARG_MEASURED_AT = "measured_at"
+        private const val ARG_RECORD_ID = "record_id" // AI 분석용 녹음 파일 ID
 
         // 신규 등록 모드
         fun newInstance(maxDb: Double, avgDb: Double, duration: Long, measuredAt: Long) =

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogFormFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogFormFragment.kt
@@ -127,12 +127,7 @@ class NoiseLogFormFragment : Fragment() {
             findNavController().popBackStack()
         }
 
-        binding.btnGenerateAiDiary.setOnClickListener {
-            if (validateInput()) {
-                generateAiDiary()
-            }
-        }
-
+        // 저장 버튼
         binding.btnSave.setOnClickListener {
             if (validateInput()) {
                 saveNoiseLog()
@@ -181,22 +176,6 @@ class NoiseLogFormFragment : Fragment() {
         return true
     }
 
-    // AI 일기 생성 - AI 서버에 요청하여 자동 일기 생성
-    private fun generateAiDiary() {
-        val memo = binding.etMemo.text.toString()
-
-        // 임시 AI 일기 생성 로직 (실제로는 서버 응답 사용)
-        val aiGeneratedDiary = buildString {
-            append("[$selectedNoiseType] $memo\n\n")
-            append("측정 시간: ${duration}초 동안 ")
-            append("최대 ${maxDb.toInt()}dB, 평균 ${avgDb.toInt()}dB의 소음이 감지되었습니다. ")
-            append("이러한 수준의 소음은 일상생활에 불편을 초래할 수 있으며, ")
-            append("지속적으로 발생할 경우 층간소음 문제로 발전할 가능성이 있습니다.")
-        }
-
-        binding.etMemo.setText(aiGeneratedDiary)
-        Toast.makeText(requireContext(), "AI 일기가 생성되었습니다", Toast.LENGTH_SHORT).show()
-    }
 
     private fun saveNoiseLog() {
         val noiseLog = NoiseLog(

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogViewModel.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogViewModel.kt
@@ -16,15 +16,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import java.time.Instant
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 import java.util.Date
 import javax.inject.Inject
-import com.kau.ttokttok.data.remote.dto.noisecalendar.res.GetDailyCalendarRes
-import com.kau.ttokttok.data.remote.dto.noisecalendar.res.DailyCalendarRecord
-import java.time.LocalDateTime
 import android.util.Log
 
 /**
@@ -176,16 +173,8 @@ class NoiseLogViewModel @Inject constructor(
     // 새로운 소음 일기 저장 - Repository를 통해 서버에 저장
     fun saveLog(log: NoiseLog) {
         viewModelScope.launch {
-            val req = CreateNoiseRecordReq(
-                occuredAt = log.measuredAt.toIsoStringZ(),
-                duration = log.duration.toInt(), // 측정 duration(초)을 서버로 전달
-                dbHigh = log.maxDecibel,
-                dbAvg = log.avgDecibel,
-                category = mapCategory(log.noiseType),
-                grade = mapGrade(log.avgDecibel),
-                description = log.memo,
-                summary = log.memo   // 등록 시에도 summary에 메모를 함께 전달
-            )
+            // Request DTO의 from() 팩토리 함수 사용 (Date → String 변환)
+            val req = CreateNoiseRecordReq.from(log)
 
             when (val result = safeApiCall { noiseRecordApiService.createNoiseRecord(req) }) {
                 is NetworkResult.Success -> {
@@ -198,14 +187,8 @@ class NoiseLogViewModel @Inject constructor(
                     // 서버가 등록 시 description만 저장하고 summary는 null로 주는 문제 해결:
                     // 즉시 수정 API를 호출해서 summary에도 메모를 저장
                     if (result.data.summary.isNullOrBlank() && !log.memo.isNullOrBlank()) {
-                        val patchReq = ModifyNoiseRecordReq(
-                            category = mapCategory(log.noiseType),
-                            occuredAt = log.measuredAt.toIsoStringZ(),
-                            noiseGrade = mapGrade(log.avgDecibel),
-                            dbHigh = log.maxDecibel,
-                            dbAvg = log.avgDecibel,
-                            summary = log.memo
-                        )
+                        // Request DTO의 from() 팩토리 함수 사용
+                        val patchReq = ModifyNoiseRecordReq.from(log)
 
                         // 백그라운드로 수정 API 호출 (실패해도 무시)
                         viewModelScope.launch {
@@ -235,15 +218,8 @@ class NoiseLogViewModel @Inject constructor(
     fun updateLog(log: NoiseLog) {
         viewModelScope.launch {
             val id = log.id?.toLongOrNull() ?: return@launch
-            val req = ModifyNoiseRecordReq(
-                category = mapCategory(log.noiseType),
-                // 생성 API와 동일하게 UTC 기준 ISO_OFFSET_DATE_TIME 포맷 사용
-                occuredAt = log.measuredAt.toIsoStringZ(),
-                noiseGrade = mapGrade(log.avgDecibel),
-                dbHigh = log.maxDecibel,
-                dbAvg = log.avgDecibel,
-                summary = log.memo
-            )
+            // Request DTO의 from() 팩토리 함수 사용 (Date → String 변환)
+            val req = ModifyNoiseRecordReq.from(log)
 
             when (val result = safeApiCall { noiseRecordApiService.modifyNoiseRecord(id, req) }) {
                 is NetworkResult.Success -> {
@@ -413,48 +389,5 @@ class NoiseLogViewModel @Inject constructor(
         fetchAverageNoiseDb()
         val cal = java.util.Calendar.getInstance()
         fetchMonthlyCalendar(cal.get(java.util.Calendar.YEAR), cal.get(java.util.Calendar.MONTH) + 1)
-    }
-
-    private fun mapCategory(noiseType: String): String = when (noiseType.uppercase()) {
-        "FOOTSTEPS", "발걸음" -> "FOOTSTEPS"
-        "HAMMERING", "망치질" -> "HAMMERING"
-        "FURNITURE", "가구" -> "FURNITURE"
-        "MUSIC", "음악" -> "MUSIC"
-        else -> "UNKNOWN"
-    }
-
-    private fun mapGrade(avg: Double): String = when {
-        avg >= 65 -> "LOUD"
-        avg >= 45 -> "NORMAL"
-        else -> "QUIET"
-    }
-
-    private fun Date.toIsoStringZ(): String =
-        Instant.ofEpochMilli(time).atOffset(ZoneOffset.UTC).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
-
-    private fun Date.toIsoStringNoZ(): String =
-        Instant.ofEpochMilli(time).atOffset(ZoneOffset.systemDefault().rules.getOffset(Instant.ofEpochMilli(time)))
-            .toLocalDateTime().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-
-    private fun DailyCalendarRecord.toDomain(): NoiseLog {
-        val occured = LocalDateTime.parse(occuredAt, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-        val measuredDate = Date.from(occured.atZone(ZoneOffset.systemDefault()).toInstant())
-
-        // 메모 우선순위: summary(수정 시) > description(등록 시) > 빈 문자열
-        val memoText = when {
-            !summary.isNullOrBlank() -> summary
-            !description.isNullOrBlank() -> description
-            else -> ""
-        }
-
-        return NoiseLog(
-            id = recordId.toString(),
-            noiseType = category,
-            maxDecibel = dbHigh,
-            avgDecibel = dbAvg,
-            memo = memoText,
-            measuredAt = measuredDate,
-            hasReport = false
-        )
     }
 }

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogViewModel.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogViewModel.kt
@@ -309,15 +309,35 @@ class NoiseLogViewModel @Inject constructor(
     // 리포트 생성
     fun createReport(selectedIds: List<String>) {
         viewModelScope.launch {
-            val ids = selectedIds.mapNotNull { it.toLongOrNull() }
+            // 현재 선택된 로그들 중 실제 객체 조회
+            val selectedLogs = _selectedLogs.value.filter { it.id in selectedIds }
+
+            // 이미 리포트를 보낸 로그 필터링
+            val logsForReport = selectedLogs.filter { !it.hasReport }
+            val alreadyReportedCount = selectedLogs.size - logsForReport.size
+
+            if (logsForReport.isEmpty()) {
+                Log.w("NoiseLogViewModel", "createReport 호출되었지만, 이미 리포트가 생성된 일기만 선택됨")
+                _uiMessage.value = "이미 소음현황판으로 전송된 일기입니다. 다시 전송할 수 없습니다."
+                return@launch
+            }
+
+            if (alreadyReportedCount > 0) {
+                Log.w(
+                    "NoiseLogViewModel",
+                    "createReport: ${alreadyReportedCount}개는 이미 리포트가 생성된 일기라 건너뜀"
+                )
+            }
+
+            val ids = logsForReport.mapNotNull { it.id?.toLongOrNull() }
             if (ids.isEmpty()) {
-                Log.w("NoiseLogViewModel", "createReport 호출됐지만 유효한 ID가 없음")
+                Log.w("NoiseLogViewModel", "createReport 호출되었지만 유효한 ID가 없음")
                 return@launch
             }
 
             Log.d("NoiseLogViewModel", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
             Log.d("NoiseLogViewModel", "리포트 생성 API 호출 시작")
-            Log.d("NoiseLogViewModel", "선택된 소음 일기 개수: ${ids.size}개")
+            Log.d("NoiseLogViewModel", "선택된 소음 일기 개수: ${ids.size}개 (실제 전송 대상)")
             Log.d("NoiseLogViewModel", "요청 URL: POST /noise/records/{recordId}/send")
             Log.d("NoiseLogViewModel", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
@@ -326,7 +346,6 @@ class NoiseLogViewModel @Inject constructor(
 
             // 각 소음 일기에 대해 개별적으로 소음현황판 전송
             ids.forEach { recordId ->
-                // 전송할 소음 일기 정보 조회
                 val noiseLog = _selectedLogs.value.find { it.id == recordId.toString() }
 
                 Log.d("NoiseLogViewModel", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
@@ -348,6 +367,10 @@ class NoiseLogViewModel @Inject constructor(
                         Log.d("NoiseLogViewModel", "  - 생성된 소음현황판 게시글 ID: ${result.data}")
                         Log.d("NoiseLogViewModel", "  - AI가 description을 분석하여 summary 자동 생성됨")
                         Log.d("NoiseLogViewModel", "  💡 소음현황판에서 확인하세요!")
+
+                        // TODO: 서버 응답에 hasReport 상태가 포함되면, 해당 값을 기준으로 동기화 필요
+                        // 여기서는 일단 로컬 모델만 true로 토글
+                        toggleReportState(recordId.toString())
                     }
                     is NetworkResult.Error -> {
                         failCount++
@@ -369,7 +392,7 @@ class NoiseLogViewModel @Inject constructor(
                     }
                 }
                 successCount == 0 -> {
-                    "소음현황판 전송에 실패했습니다. 잠시 후 다시 시도해 주세요."
+                    "소음현황판 전송에 실패했습니다. 잠시 후 다시 시도해주세요."
                 }
                 else -> {
                     "${successCount}개 성공, ${failCount}개 실패했습니다"
@@ -379,17 +402,18 @@ class NoiseLogViewModel @Inject constructor(
             _uiMessage.value = resultMessage
 
             Log.d("NoiseLogViewModel", "")
-            Log.d("NoiseLogViewModel", "📊 전송 결과 요약:")
-            Log.d("NoiseLogViewModel", "  - 성공: ${successCount}개")
-            Log.d("NoiseLogViewModel", "  - 실패: ${failCount}개")
-            Log.d("NoiseLogViewModel", "  - 사용자 메시지: $resultMessage")
+        }
+    }
 
-            // 전송 후 헤더/리스트 갱신
-            if (successCount > 0) {
-                Log.d("NoiseLogViewModel", "  🔄 소음일기 데이터 새로고침 중...")
-                refreshHeaderCounters()
-                selectDate(_selectedDate.value)
-            }
+    // 이미 정의된 함수: hasReport 토글
+    fun toggleReportState(id: String) {
+        val current = _selectedLogs.value.toMutableList()
+        val index = current.indexOfFirst { it.id == id }
+        if (index != -1) {
+            val log = current[index]
+            val updated = log.copy(hasReport = !log.hasReport)
+            current[index] = updated
+            _selectedLogs.value = current
         }
     }
 

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogViewModel.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseLogViewModel.kt
@@ -181,21 +181,8 @@ class NoiseLogViewModel @Inject constructor(
                     // 서버 응답 확인용 로그
                     Log.d(
                         "NoiseLogViewModel",
-                        "createNoiseRecord 성공 - id=${result.data.id}, description=${result.data.description}, summary=${result.data.summary}"
+                        "createNoiseRecord 성공 - id=${result.data.id}, description=${result.data.description}"
                     )
-
-                    // 서버가 등록 시 description만 저장하고 summary는 null로 주는 문제 해결:
-                    // 즉시 수정 API를 호출해서 summary에도 메모를 저장
-                    if (result.data.summary.isNullOrBlank() && !log.memo.isNullOrBlank()) {
-                        // Request DTO의 from() 팩토리 함수 사용
-                        val patchReq = ModifyNoiseRecordReq.from(log)
-
-                        // 백그라운드로 수정 API 호출 (실패해도 무시)
-                        viewModelScope.launch {
-                            safeApiCall { noiseRecordApiService.modifyNoiseRecord(result.data.id, patchReq) }
-                            Log.d("NoiseLogViewModel", "등록 직후 summary 업데이트 완료")
-                        }
-                    }
 
                     // 로컬 목록도 갱신해 화면 반영
                     repository.saveNoiseLog(log)
@@ -337,36 +324,52 @@ class NoiseLogViewModel @Inject constructor(
             var successCount = 0
             var failCount = 0
 
-            // 각 소음 일기에 대해 개별적으로 리포트 생성
+            // 각 소음 일기에 대해 개별적으로 소음현황판 전송
             ids.forEach { recordId ->
-                Log.d("NoiseLogViewModel", "리포트 전송 중... recordId=$recordId")
+                // 전송할 소음 일기 정보 조회
+                val noiseLog = _selectedLogs.value.find { it.id == recordId.toString() }
+
+                Log.d("NoiseLogViewModel", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+                Log.d("NoiseLogViewModel", "소음현황판 전송 중... recordId=$recordId")
+                noiseLog?.let {
+                    Log.d("NoiseLogViewModel", "📋 전송할 소음일기 정보:")
+                    Log.d("NoiseLogViewModel", "  - 소음 종류: ${it.noiseType}")
+                    Log.d("NoiseLogViewModel", "  - 최대 데시벨: ${it.maxDecibel}dB")
+                    Log.d("NoiseLogViewModel", "  - 평균 데시벨: ${it.avgDecibel}dB")
+                    Log.d("NoiseLogViewModel", "  - 측정 시간: ${it.duration}초")
+                    Log.d("NoiseLogViewModel", "  - Description(사용자 메모): ${it.memo}")
+                    Log.d("NoiseLogViewModel", "  ⬇️ 이 description을 AI가 분석하여 summary 자동 생성")
+                }
 
                 when (val result = safeApiCall { reportApiService.createReport(recordId) }) {
                     is NetworkResult.Success -> {
                         successCount++
-                        Log.d("NoiseLogViewModel", "✅ 리포트 전송 성공! (recordId=$recordId)")
-                        Log.d("NoiseLogViewModel", "  - 생성된 소음현황 게시글 ID: ${result.data}")
+                        Log.d("NoiseLogViewModel", "✅ 소음현황판 전송 성공! (recordId=$recordId)")
+                        Log.d("NoiseLogViewModel", "  - 생성된 소음현황판 게시글 ID: ${result.data}")
+                        Log.d("NoiseLogViewModel", "  - AI가 description을 분석하여 summary 자동 생성됨")
+                        Log.d("NoiseLogViewModel", "  💡 소음현황판에서 확인하세요!")
                     }
                     is NetworkResult.Error -> {
                         failCount++
-                        Log.e("NoiseLogViewModel", "❌ 리포트 전송 실패! (recordId=$recordId)")
+                        Log.e("NoiseLogViewModel", "❌ 소음현황판 전송 실패! (recordId=$recordId)")
                         Log.e("NoiseLogViewModel", "  - HTTP 코드: ${result.code}")
                         Log.e("NoiseLogViewModel", "  - 에러 메시지: ${result.message}")
                     }
                 }
+                Log.d("NoiseLogViewModel", "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
             }
 
             // 결과 메시지 표시
             val resultMessage = when {
                 failCount == 0 -> {
                     if (successCount == 1) {
-                        "리포트가 소음현황 페이지로 전송되었습니다"
+                        "소음현황판으로 전송되었습니다 (AI 요약 자동 생성)"
                     } else {
-                        "${successCount}개의 리포트가 소음현황 페이지로 전송되었습니다"
+                        "${successCount}개가 소음현황판으로 전송되었습니다 (AI 요약 자동 생성)"
                     }
                 }
                 successCount == 0 -> {
-                    "리포트 전송에 실패했습니다. 잠시 후 다시 시도해 주세요."
+                    "소음현황판 전송에 실패했습니다. 잠시 후 다시 시도해 주세요."
                 }
                 else -> {
                     "${successCount}개 성공, ${failCount}개 실패했습니다"
@@ -375,8 +378,15 @@ class NoiseLogViewModel @Inject constructor(
 
             _uiMessage.value = resultMessage
 
-            // 리포트 생성 후 헤더/리스트 갱신
+            Log.d("NoiseLogViewModel", "")
+            Log.d("NoiseLogViewModel", "📊 전송 결과 요약:")
+            Log.d("NoiseLogViewModel", "  - 성공: ${successCount}개")
+            Log.d("NoiseLogViewModel", "  - 실패: ${failCount}개")
+            Log.d("NoiseLogViewModel", "  - 사용자 메시지: $resultMessage")
+
+            // 전송 후 헤더/리스트 갱신
             if (successCount > 0) {
+                Log.d("NoiseLogViewModel", "  🔄 소음일기 데이터 새로고침 중...")
                 refreshHeaderCounters()
                 selectDate(_selectedDate.value)
             }

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseMeasurementFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseMeasurementFragment.kt
@@ -334,21 +334,26 @@ class NoiseMeasurementFragment : Fragment() {
 
     private suspend fun uploadRecordingFileAndNavigate(recordingFile: File) {
         try {
+            // 1️⃣ 로컬에 영구 저장
+            saveRecordingToLocalStorage(recordingFile)
+
             withContext(Dispatchers.Main) {
                 Toast.makeText(requireContext(), "녹음 파일 업로드 중...", Toast.LENGTH_SHORT).show()
             }
 
+            // 2️⃣ 서버에 업로드
             val result = recordingRepository.uploadRecording(recordingFile)
             result.onSuccess { response ->
                 recordingFilePath = response.fileUrl // 업로드된 URL로 교체
+
                 withContext(Dispatchers.Main) {
-                    Toast.makeText(requireContext(), "업로드 완료!", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(requireContext(), "업로드 완료! (로컬 저장됨)", Toast.LENGTH_SHORT).show()
                     moveToNoiseLogForm()
                 }
             }.onFailure { e ->
                 withContext(Dispatchers.Main) {
-                    Toast.makeText(requireContext(), "업로드 실패: ${e.message}", Toast.LENGTH_SHORT).show()
-                    // 실패해도 이동은 가능하도록
+                    Toast.makeText(requireContext(), "업로드 실패: ${e.message} (로컬 저장됨)", Toast.LENGTH_SHORT).show()
+                    // 실패해도 로컬에는 저장됨
                     moveToNoiseLogForm()
                 }
             }
@@ -414,6 +419,33 @@ class NoiseMeasurementFragment : Fragment() {
         isPlaying = false
         binding.btnPlayRecording.text = "녹음 재생"
         binding.btnPlayRecording.setIconResource(android.R.drawable.ic_media_play)
+    }
+
+    // ═══════════════════════════════
+    // 로컬 저장 관련 함수
+    // ═══════════════════════════════
+
+    /**
+     * 녹음 파일을 앱 내부 저장소에 영구 저장
+     * 위치: /data/data/com.kau.ttokttok/files/recordings/
+     */
+    private suspend fun saveRecordingToLocalStorage(sourceFile: File): File = withContext(Dispatchers.IO) {
+        try {
+            // 앱 전용 저장소에 영구 저장 (앱 삭제 전까지 유지)
+            val recordingsDir = File(requireContext().filesDir, "recordings")
+            if (!recordingsDir.exists()) {
+                recordingsDir.mkdirs()
+            }
+
+            val destFile = File(recordingsDir, "recording_${System.currentTimeMillis()}.m4a")
+            sourceFile.copyTo(destFile, overwrite = true)
+
+            android.util.Log.d("NoiseMeasurement", "✅ Recording saved locally: ${destFile.absolutePath}")
+            destFile
+        } catch (e: Exception) {
+            android.util.Log.e("NoiseMeasurement", "❌ Failed to save recording locally", e)
+            sourceFile // 실패 시 원본 반환
+        }
     }
 
     private fun computeRms(buffer: ShortArray, read: Int) = // RMS(Root Mean Square) 계산

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseMeasurementFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseMeasurementFragment.kt
@@ -221,11 +221,19 @@ class NoiseMeasurementFragment : Fragment() {
     private suspend fun processAudioBuffer(buffer: ShortArray, read: Int) { // 오디오 버퍼 분석 및 데시벨 계산
         val rmsRaw = computeRms(buffer, read)
         rmsEma = rmsEma?.let { RMS_EMA_ALPHA * rmsRaw + (1 - RMS_EMA_ALPHA) * it } ?: rmsRaw
+
         if (baselineRms == null) {
             performCalibration(rmsEma!!)
+            android.util.Log.d("NoiseMeasurement", "📏 Calibration... rmsEma=${rmsEma}")
             return
         }
+
         val displayDb = calculateAndSmoothDb(rmsEma!!)
+        android.util.Log.d(
+            "NoiseMeasurement",
+            "🎧 Frame: effRms=${String.format("%.2f", rmsEma)} baseline=${String.format("%.2f", baselineRms)} dB=${String.format("%.1f", displayDb)}"
+        )
+
         synchronized(dbList) {
             dbList.add(displayDb)
             if (displayDb > maxDb) maxDb = displayDb
@@ -239,16 +247,25 @@ class NoiseMeasurementFragment : Fragment() {
         if (++calibrationCount >= CALIBRATION_FRAMES) {
             calibrationRmsList.sort()
             val idx = (calibrationRmsList.size * 0.25).toInt().coerceIn(0, calibrationRmsList.lastIndex)
-            baselineRms = calibrationRmsList[idx].coerceAtLeast(10.0)
+            // 너무 큰 기준이 잡혀버리면 항상 5dB로 깔리는 현상이 있으니 상/하한을 둔다.
+            baselineRms = calibrationRmsList[idx]
+                .coerceAtLeast(1.0)      // 0에 너무 가깝지 않게
+                .coerceAtMost(2000.0)    // 과도하게 큰 값 방지
+            android.util.Log.d(
+                "NoiseMeasurement",
+                "✅ Calibration done: baselineRms=${String.format("%.2f", baselineRms)} (idx=$idx, size=${calibrationRmsList.size})"
+            )
         }
     }
 
     private fun calculateAndSmoothDb(effRms: Double): Double { // RMS를 실제 데시벨로 변환
-        val ratio = (effRms / baselineRms!!).coerceAtLeast(0.01)
+        // ratio가 항상 0.01로 깔리지 않도록 하한/상한을 완화
+        val ratio = (effRms / baselineRms!!).coerceIn(0.1, 50.0)
         val relativeDb = 20.0 * log10(ratio)
-        val scaleFactor = 1.5 // 민감도 조정
+        val scaleFactor = 1.3 // 민감도 약간 완화
         val rawDb = BASE_DB + (relativeDb * scaleFactor)
-        val clampedDb = rawDb.coerceIn(5.0, 85.0) // 실제 측정 가능한 범위로 제한
+        val clampedDb = rawDb.coerceIn(10.0, 85.0) // 바닥값을 10dB로 약간 올림
+
         smoothedDb = smoothedDb?.let { prev -> // 급격한 변화를 부드럽게 처리
             val diff = clampedDb - prev
             when {
@@ -257,6 +274,7 @@ class NoiseMeasurementFragment : Fragment() {
                 else -> kotlin.math.max(clampedDb, prev - RELEASE_RATE_PER_TICK)
             }
         } ?: clampedDb
+
         return smoothedDb!!
     }
 
@@ -328,12 +346,14 @@ class NoiseMeasurementFragment : Fragment() {
             }
         } else {
             // 녹음 파일이 없으면 바로 이동
-            moveToNoiseLogForm()
+            navigateWithRecordId(null)
         }
     }
 
     private suspend fun uploadRecordingFileAndNavigate(recordingFile: File) {
         try {
+            var uploadedRecordId: Long? = null
+
             // 1️⃣ 로컬에 영구 저장
             saveRecordingToLocalStorage(recordingFile)
 
@@ -344,17 +364,20 @@ class NoiseMeasurementFragment : Fragment() {
             // 2️⃣ 서버에 업로드
             val result = recordingRepository.uploadRecording(recordingFile)
             result.onSuccess { response ->
-                recordingFilePath = response.fileUrl // 업로드된 URL로 교체
+                uploadedRecordId = response.recordingId
+                android.util.Log.d("NoiseMeasurementFragment", "✅ 녹음 파일 업로드 성공!")
+                android.util.Log.d("NoiseMeasurementFragment", "  - recordId: ${response.recordingId}")
 
                 withContext(Dispatchers.Main) {
                     Toast.makeText(requireContext(), "업로드 완료! (로컬 저장됨)", Toast.LENGTH_SHORT).show()
-                    moveToNoiseLogForm()
+                    navigateWithRecordId(uploadedRecordId)
                 }
             }.onFailure { e ->
+                android.util.Log.e("NoiseMeasurementFragment", "❌ 업로드 실패: ${e.message}", e)
                 withContext(Dispatchers.Main) {
                     Toast.makeText(requireContext(), "업로드 실패: ${e.message} (로컬 저장됨)", Toast.LENGTH_SHORT).show()
-                    // 실패해도 로컬에는 저장됨
-                    moveToNoiseLogForm()
+                    // 실패해도 화면은 이동
+                    navigateWithRecordId(null)
                 }
             }
         } catch (e: Exception) {
@@ -362,20 +385,23 @@ class NoiseMeasurementFragment : Fragment() {
             withContext(Dispatchers.Main) {
                 if (isAdded) {
                     Toast.makeText(requireContext(), "오류 발생: ${e.message}", Toast.LENGTH_SHORT).show()
-                    moveToNoiseLogForm()
+                    navigateWithRecordId(null)
                 }
             }
         }
     }
 
-    private fun moveToNoiseLogForm() {
+    private fun navigateWithRecordId(recordId: Long?) {
         val bundle = Bundle().apply {
             putDouble("max_db", maxDb)
             putDouble("avg_db", avgDb)
             putLong("duration", (System.currentTimeMillis() - startTime) / 1000)
             putLong("measured_at", startTime)
-            recordingFilePath?.let { putString("recording_url", it) }
+            recordId?.let { putLong("record_id", it) }
         }
+
+        android.util.Log.d("NoiseMeasurementFragment", "📋 소음일기 작성 화면으로 이동")
+        android.util.Log.d("NoiseMeasurementFragment", "  - recordId: $recordId")
 
         findNavController().navigateTo(Destination.NOISE_LOG_FORM, bundle)
     }

--- a/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseMeasurementFragment.kt
+++ b/app/src/main/java/com/kau/ttokttok/ui/xml/calendar/NoiseMeasurementFragment.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.pm.PackageManager
 import android.media.AudioFormat
 import android.media.AudioRecord
+import android.media.MediaPlayer
 import android.media.MediaRecorder
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -16,24 +17,37 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.kau.ttokttok.databinding.FragmentNoiseMeasurementBinding
+import com.kau.ttokttok.domain.repository.RecordingRepository
 import com.kau.ttokttok.ui.navigation.Destination
 import com.kau.ttokttok.ui.navigation.navigateTo
+import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
 import java.util.Locale
 import kotlin.coroutines.coroutineContext
 import kotlin.math.log10
 import kotlin.math.sqrt
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class NoiseMeasurementFragment : Fragment() {
     private var _binding: FragmentNoiseMeasurementBinding? = null
     private val binding get() = _binding!!
+
+    @Inject
+    lateinit var recordingRepository: RecordingRepository
+
     private var audioRecord: AudioRecord? = null
+    private var mediaRecorder: MediaRecorder? = null
+    private var mediaPlayer: MediaPlayer? = null
+    private var recordingFilePath: String? = null
     private var isRecording = false
+    private var isPlaying = false
     private var recordingJob: Job? = null
     private var timerJob: Job? = null
     private var maxDb = 0.0
@@ -65,7 +79,13 @@ class NoiseMeasurementFragment : Fragment() {
             findNavController().popBackStack()
         }
         binding.btnControl.setOnClickListener {
-            if (isRecording) stopMeasurementAndNavigate() else checkPermissionAndStart()
+            if (isRecording) stopMeasurementAndShowButtons() else checkPermissionAndStart()
+        }
+        binding.btnPlayRecording.setOnClickListener {
+            togglePlayRecording()
+        }
+        binding.btnComplete.setOnClickListener {
+            navigateToNoiseLogForm()
         }
         updateControlButton(false)
     }
@@ -94,7 +114,7 @@ class NoiseMeasurementFragment : Fragment() {
         }
     }
 
-    private fun startMeasurement() { // AudioRecord 초기화 및 측정 시작
+    private fun startMeasurement() { // AudioRecord 초기화 및 측정 시작, MediaRecorder로 녹음
         if (isRecording) return
         try {
             val bufferSize = AudioRecord.getMinBufferSize(SAMPLE_RATE, CHANNEL_CONFIG, AUDIO_FORMAT)
@@ -103,11 +123,39 @@ class NoiseMeasurementFragment : Fragment() {
                 return
             }
             resetMeasurementState()
+
+            // MediaRecorder로 녹음 시작 (M4A 형식 - AI 분석 최적화)
+            recordingFilePath = "${requireContext().externalCacheDir?.absolutePath}/noise_${System.currentTimeMillis()}.m4a"
+            mediaRecorder = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                MediaRecorder(requireContext())
+            } else {
+                @Suppress("DEPRECATION")
+                MediaRecorder()
+            }.apply {
+                setAudioSource(MediaRecorder.AudioSource.MIC)
+                // AAC_ADTS 형식 사용 - 순수 오디오 전용 AAC
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
+                    setOutputFormat(MediaRecorder.OutputFormat.AAC_ADTS) // M4A/AAC 오디오 전용
+                } else {
+                    setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+                }
+                setAudioEncoder(MediaRecorder.AudioEncoder.AAC)
+                setAudioEncodingBitRate(128000) // 128kbps
+                setAudioSamplingRate(44100) // 44.1kHz
+                setOutputFile(recordingFilePath)
+                prepare()
+                start()
+            }
+
+            // AudioRecord로 데시벨 측정
             audioRecord = createBestAudioRecord(bufferSize)
             if (audioRecord?.state != AudioRecord.STATE_INITIALIZED) {
                 Toast.makeText(requireContext(), "마이크를 초기화할 수 없습니다", Toast.LENGTH_SHORT).show()
                 audioRecord?.release()
                 audioRecord = null
+                mediaRecorder?.stop()
+                mediaRecorder?.release()
+                mediaRecorder = null
                 return
             }
             audioRecord?.startRecording()
@@ -212,7 +260,6 @@ class NoiseMeasurementFragment : Fragment() {
         return smoothedDb!!
     }
 
-
     private suspend fun handleRecordingError(message: String) {
         withContext(Dispatchers.Main) {
             Toast.makeText(requireContext(), message, Toast.LENGTH_SHORT).show()
@@ -246,22 +293,127 @@ class NoiseMeasurementFragment : Fragment() {
         audioRecord?.stop()
         audioRecord?.release()
         audioRecord = null
+
+        try {
+            mediaRecorder?.stop()
+            mediaRecorder?.release()
+            mediaRecorder = null
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+
         updateControlButton(false)
     }
 
-    private fun stopMeasurementAndNavigate() { // 측정 종료 후 결과 화면으로 이동
+    private fun stopMeasurementAndShowButtons() { // 측정 종료 후 재생/완료 버튼 표시
         stopMeasurement()
 
+        // 녹음 파일이 존재하면 재생 및 완료 버튼 표시
+        val recordingFile = recordingFilePath?.let { File(it) }
+        if (recordingFile != null && recordingFile.exists()) {
+            binding.recordingActionsContainer.visibility = View.VISIBLE
+            Toast.makeText(requireContext(), "측정이 완료되었습니다", Toast.LENGTH_SHORT).show()
+        } else {
+            // 녹음 파일이 없으면 바로 소음일기 작성 페이지로 이동
+            navigateToNoiseLogForm()
+        }
+    }
+
+    private fun navigateToNoiseLogForm() { // 소음일기 작성 페이지로 이동 (완료 버튼 클릭 시)
+        // 녹음 파일이 있으면 업로드 후 이동
+        val recordingFile = recordingFilePath?.let { File(it) }
+        if (recordingFile != null && recordingFile.exists()) {
+            viewLifecycleOwner.lifecycleScope.launch {
+                uploadRecordingFileAndNavigate(recordingFile)
+            }
+        } else {
+            // 녹음 파일이 없으면 바로 이동
+            moveToNoiseLogForm()
+        }
+    }
+
+    private suspend fun uploadRecordingFileAndNavigate(recordingFile: File) {
+        try {
+            withContext(Dispatchers.Main) {
+                Toast.makeText(requireContext(), "녹음 파일 업로드 중...", Toast.LENGTH_SHORT).show()
+            }
+
+            val result = recordingRepository.uploadRecording(recordingFile)
+            result.onSuccess { response ->
+                recordingFilePath = response.fileUrl // 업로드된 URL로 교체
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(requireContext(), "업로드 완료!", Toast.LENGTH_SHORT).show()
+                    moveToNoiseLogForm()
+                }
+            }.onFailure { e ->
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(requireContext(), "업로드 실패: ${e.message}", Toast.LENGTH_SHORT).show()
+                    // 실패해도 이동은 가능하도록
+                    moveToNoiseLogForm()
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            withContext(Dispatchers.Main) {
+                if (isAdded) {
+                    Toast.makeText(requireContext(), "오류 발생: ${e.message}", Toast.LENGTH_SHORT).show()
+                    moveToNoiseLogForm()
+                }
+            }
+        }
+    }
+
+    private fun moveToNoiseLogForm() {
         val bundle = Bundle().apply {
             putDouble("max_db", maxDb)
             putDouble("avg_db", avgDb)
             putLong("duration", (System.currentTimeMillis() - startTime) / 1000)
             putLong("measured_at", startTime)
-            // putString("measurement_id", measurementId)
+            recordingFilePath?.let { putString("recording_url", it) }
         }
 
         findNavController().navigateTo(Destination.NOISE_LOG_FORM, bundle)
-        Toast.makeText(requireContext(), "측정이 완료되었습니다", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun togglePlayRecording() { // 녹음 파일 재생/정지
+        if (recordingFilePath == null || !File(recordingFilePath!!).exists()) {
+            Toast.makeText(requireContext(), "재생할 녹음 파일이 없습니다", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        if (isPlaying) {
+            stopPlayback()
+        } else {
+            startPlayback()
+        }
+    }
+
+    private fun startPlayback() {
+        try {
+            mediaPlayer = MediaPlayer().apply {
+                setDataSource(recordingFilePath)
+                prepare()
+                setOnCompletionListener {
+                    stopPlayback()
+                }
+                start()
+            }
+            isPlaying = true
+            binding.btnPlayRecording.text = "재생 중지"
+            binding.btnPlayRecording.setIconResource(android.R.drawable.ic_media_pause)
+        } catch (e: Exception) {
+            e.printStackTrace()
+            Toast.makeText(requireContext(), "재생 중 오류가 발생했습니다: ${e.message}", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun stopPlayback() {
+        mediaPlayer?.stop()
+        mediaPlayer?.release()
+        mediaPlayer = null
+        isPlaying = false
+        binding.btnPlayRecording.text = "녹음 재생"
+        binding.btnPlayRecording.setIconResource(android.R.drawable.ic_media_play)
     }
 
     private fun computeRms(buffer: ShortArray, read: Int) = // RMS(Root Mean Square) 계산
@@ -277,6 +429,7 @@ class NoiseMeasurementFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         stopMeasurement()
+        stopPlayback()
         _binding = null
     }
 

--- a/app/src/main/res/layout/fragment_noise_log_form.xml
+++ b/app/src/main/res/layout/fragment_noise_log_form.xml
@@ -432,17 +432,24 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="간단한 메모 *"
+            android:text="메모 *"
             android:textColor="#f1f5f9"
             android:textSize="16sp"
             android:textStyle="bold"
+            android:layout_marginBottom="8dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="💡 소음현황판 전송 시 AI가 자동으로 요약해드립니다"
+            android:textColor="#94a3b8"
+            android:textSize="12sp"
             android:layout_marginBottom="12dp" />
 
         <EditText
             android:id="@+id/etMemo"
             android:layout_width="match_parent"
             android:layout_height="120dp"
-            android:layout_marginBottom="16dp"
             android:background="@drawable/bg_input"
             android:gravity="top|start"
             android:hint="소음의 특징이나 상황을 간단히 기록해주세요 (필수)\n예: 무거운 물건을 끄는 소리가 반복적으로 들림"
@@ -450,28 +457,8 @@
             android:padding="16dp"
             android:textSize="14sp"
             android:textColor="#f1f5f9"
-            android:textColorHint="#94a3b8" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="AI가 메모를 바탕으로 상세한 일기를 작성해드립니다"
-            android:textColor="#94a3b8"
-            android:textSize="12sp"
-            android:layout_marginBottom="12dp" />
-
-        <!-- AI 일기 자동 생성 버튼 -->
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btnGenerateAiDiary"
-            android:layout_width="match_parent"
-            android:layout_height="56dp"
-            android:layout_marginBottom="16dp"
-            android:text="✨ AI로 일기 자동 생성하기"
-            android:textColor="@android:color/white"
-            android:textSize="16sp"
-            android:textStyle="bold"
-            app:backgroundTint="@color/ai_purple"
-            app:cornerRadius="12dp" />
+            android:textColorHint="#94a3b8"
+            android:layout_marginBottom="16dp" />
 
         <!-- 저장 버튼 -->
         <com.google.android.material.button.MaterialButton

--- a/app/src/main/res/layout/fragment_noise_measurement.xml
+++ b/app/src/main/res/layout/fragment_noise_measurement.xml
@@ -234,6 +234,46 @@
 
         </LinearLayout>
 
+        <!-- 녹음 파일 재생 및 완료 버튼 (측정 완료 후 표시) -->
+        <LinearLayout
+            android:id="@+id/recording_actions_container"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:orientation="horizontal"
+            android:gravity="center"
+            android:visibility="gone">
+
+            <!-- 녹음 파일 재생 버튼 -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnPlayRecording"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="8dp"
+                android:text="녹음 재생"
+                android:textColor="@color/colorPrimary"
+                app:icon="@android:drawable/ic_media_play"
+                app:iconTint="@color/colorPrimary"
+                app:backgroundTint="@android:color/white"
+                app:cornerRadius="24dp"
+                android:contentDescription="녹음 파일 재생" />
+
+            <!-- 측정 완료 버튼 -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnComplete"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:text="측정 완료"
+                android:textColor="@android:color/white"
+                app:icon="@android:drawable/ic_menu_send"
+                app:iconTint="@android:color/white"
+                app:backgroundTint="@color/colorPrimary"
+                app:cornerRadius="24dp"
+                android:contentDescription="측정 완료하고 일기 작성" />
+
+        </LinearLayout>
+
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- 기능 추가
- 버그 수정
- 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) feat/noise-calendar -> develop

### 변경 사항

- [x] 1. 소음 측정기를 통해 녹음 파일이 생성되도록 구현 (MediaRecord 사용)
- [x] 2. 녹음된 파일이 DB에 저장되도록 API 연동/로컬에도 저장되도록 구현 
- [x] 3. 소음 측정기 디자인 일부 변화 ->재생버튼, 측정완료 버튼 추가
- [x] 4. 네트워크 모듈에 1번에 일부 코드 추가
- [x] 5. 기타 코드 리팩토링
- [x] 6. AI 카테고리 분석 api 연동
- [x] 7. AI 소음일기 작성 api 연동

### 테스트 결과
<img width="329" height="759" alt="image" src="https://github.com/user-attachments/assets/8b099bdc-7d8d-42bd-8e7f-7af20703d3f7" />

<img width="323" height="519" alt="image" src="https://github.com/user-attachments/assets/3747c14f-d11b-4c28-8b87-c0dee9a51279" />
<img width="344" height="190" alt="image" src="https://github.com/user-attachments/assets/adebb9f4-86a0-40f1-8e13-5116de9c3d86" />
<img width="925" height="280" alt="image" src="https://github.com/user-attachments/assets/f73de882-c866-4711-93f6-b371a78304a2" />
